### PR TITLE
Bound the UMI counters: range-partition spill for UmiCounts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,8 +37,7 @@ Everything below is either open or half-open. Nothing else on this page is.
 
 | # | item | milestone | why it is next |
 |---|---|---|---|
-| 1 | `.mig` bucket output from `checkout` | M2 | the **only** unbounded allocation left: the UMI counters are 8.8 GB at NovaSeq scale, held in one piece, and this is what bounds them. `checkout` warns past 1 GB and that is a warning, not a fix |
-| 2 | Bucketed correction, two passes with the key rotated | M3 | same problem one stage on. `refine` holds the whole barcode table; a plain range partition splits a barcode from its neighbour for the top b/2 positions, so the rotation is the fix and it is understood, not designed |
+| 1+2 | **Bucketed correction, two passes with the key rotated** — then switch the spill on | M2/M3 | **these are one item, not two.** `UmiCounts` can now bound itself: `enable_spill()` range-partitions to disk and `for_each()` streams a bucket at a time, so `histogram()`, `composition()` and `distinct()` no longer need the library resident. What blocks *using* it in `checkout` is that the bindings run `correct_umis` on the same counters, and correction walks each barcode's 3L neighbourhood — which a plain range partition splits whenever the substitution lands in the partitioned bits. So the rotation has to come first: bound the memory before correction is bucketed and `checkout` would silently stop correcting. The call site is written and commented out in `src/checkout.cpp` |
 | 3 | The template's own error split | M3 | the pattern's constant bases calibrate the **primer**, not the polymerase — the fitted intercept is a synthesis defect rate. Separating sequencing from RT/PCR error needs a different standard, and until it exists `--rt-error` is a named class rather than a measurement |
 | 4 | `--rt-error auto` | M1 | falls straight out of (3). The floor is a property of the enzyme and the cycle count, so fitting it per dataset is the honest default once there is something to fit against |
 | 5 | i7xi5 contingency table | M2 | the only way index hopping is actually estimable, and it needs nothing that is not already in the headers |
@@ -180,7 +179,13 @@ structure instead of trusting the published claim that none exists (`scripts/sra
       anchor at 0. Presets for the eight chemistries with names, each carrying a citable source
 - [x] **A run that matches nothing reports the declaration error** instead of three statistics
       computed from reads that never arrived
-- [ ] `.mig` bucket output, which is also what bounds the UMI counters
+- [x] **The counter can bound itself** (2026-08-14): `UmiCounts::enable_spill()` range-partitions
+      to disk past a byte budget and `for_each()` streams one bucket at a time, reducing on read.
+      A spilled counter gives byte-identical histograms, compositions and distinct counts to a
+      resident one; `entries()`, `find()` and `merge()` throw rather than answer from the fragment
+      that happens to still be in RAM
+- [ ] Switch it on in `checkout` — blocked on bucketed correction, see item 1+2 above
+- [ ] `.mig` bucket output, which is the other half of the same partition
 - [ ] i7×i5 contingency table — the only way index hopping is actually estimable
 - Gate: per-sample counts within 2% of MIGEC v1.2.9 on the spike-ins; identical output at 1 and 8
   threads ; >1 M reads/s at 16 threads

--- a/include/migec/umi_stats.hpp
+++ b/include/migec/umi_stats.hpp
@@ -19,6 +19,8 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <functional>
+#include <string>
 #include <vector>
 
 namespace migec {
@@ -189,13 +191,20 @@ public:
     // depend on the order the threads finished in.
     void merge(const UmiCounts& other);
 
-    size_t distinct() const { flush(); return entries_.size(); }
+    // Streams when spilled, so this is O(spilled bytes) the first time and cached afterwards.
+    size_t distinct() const;
     uint64_t total() const { return total_; }
     int length() const { return length_; }
 
     // Sorted by key, ascending. Flushes first, so it is O(n log n) on the first call after adds
-    // and free afterwards.
-    const std::vector<Entry>& entries() const { flush(); return entries_; }
+    // and free afterwards. Throws if the counter has spilled -- use `for_each` instead.
+    // Never: flush BEFORE the residency check. A pending buffer can be what tips the counter over
+    // its budget, so checking first would hand back an array that is about to become a fragment.
+    const std::vector<Entry>& entries() const {
+        flush();
+        require_resident("entries()");
+        return entries_;
+    }
 
     // Read count for a packed barcode, or nullptr. Binary search over the sorted array: the top
     // levels stay resident, which is why this beats a hash probe here despite the log factor.
@@ -204,6 +213,30 @@ public:
     // Resident bytes actually held by this counter, buffer included.
     size_t memory_bytes() const;
 
+    // Bound the resident set by spilling to a range partition on disk.
+    //
+    // Without this the counter holds one sorted (key, count) array over the whole library: ~22 B
+    // per distinct barcode, 8.8 GB at NovaSeq scale, in one piece. With it, whenever the array
+    // exceeds `budget_bytes` it is split on the TOP `bits` of the key into one append-only file
+    // per bucket and dropped, so the resident set is the budget rather than the library.
+    //
+    // Never: RANGE, never hash. The same rule as `assemble`'s partition and for the same reason --
+    // a barcode and its 1-substitution neighbours have to be able to meet. Nothing here needs that
+    // yet (a histogram and a composition are per-barcode), but a hash would make the correction
+    // pass impossible to add later, and correction is the whole reason these counts exist.
+    //
+    // Never: a spilled counter can no longer serve `entries()`, because the whole point is that
+    // the entries are not all resident. `histogram()`, `composition()` and `distinct()` stream and
+    // still work; `entries()`, `find()` and everything built on them throw. `refine` does not
+    // spill -- it needs the whole table for the neighbourhood scan, and bounding THAT is a
+    // separate item with a different fix (two passes with the key rotated).
+    //
+    // Note: the same key may be written to a bucket many times, once per spill. Reduction happens
+    // when the bucket is read back, so a spill is O(1) per entry and correctness does not depend
+    // on how many times it happened.
+    void enable_spill(const std::string& directory, size_t budget_bytes, int bits);
+    bool spilled() const { return !spill_paths_.empty(); }
+
     CoverageHistogram histogram() const;
     // `weight_by_reads` draws the composition MIGEC calls `pwm.txt` (each UMI counted once per
     // read); false gives `pwm-units.txt` (each distinct UMI counted once). The unit-weighted one
@@ -211,9 +244,20 @@ public:
     // the composition.
     UmiComposition composition(bool weight_by_reads = false) const;
 
+    // Visit every (key, count) in ascending key order, exactly once per distinct key, without
+    // requiring them all to be resident. Resident counters walk the sorted array; spilled ones
+    // load one bucket at a time, reduce it, hand it over and free it -- so peak memory is the
+    // largest bucket, not the library.
+    //
+    // This is what `histogram()`, `composition()` and `distinct()` are written against, and it is
+    // why they keep working after a spill.
+    void for_each(const std::function<void(const Entry&)>& fn) const;
+
 private:
     // const because every accessor needs it and none of them change what the object *means*.
     void flush() const;
+    void spill() const;
+    void require_resident(const char* what) const;
 
     static constexpr size_t kMinBuffer = 4096;
 
@@ -223,6 +267,15 @@ private:
     uint64_t total_ = 0;
     mutable std::vector<Entry> buf_;
     mutable std::vector<Entry> entries_;
+
+    // Spill state. Empty `spill_paths_` means "never spilled", which is the resident case and the
+    // only one `refine` ever sees.
+    std::string spill_dir_;
+    size_t spill_budget_ = 0;
+    int spill_bits_ = 0;
+    mutable std::vector<std::string> spill_paths_;
+    mutable uint64_t distinct_cache_ = 0;
+    mutable bool distinct_known_ = false;
 };
 
 struct CorrectionParams {

--- a/src/checkout.cpp
+++ b/src/checkout.cpp
@@ -513,6 +513,14 @@ CheckoutStats run_checkout(const PatternSet& patterns, const CheckoutParams& par
             file_of[i] = static_cast<uint32_t>(stats.sample_ids.size());
             stats.sample_ids.push_back(ids[i]);
             stats.umi_counts.emplace_back(patterns.umi_length(i));
+            // Note: this is where `enable_spill` goes, and it is deliberately NOT called yet.
+            // `UmiCounts` can now bound itself with a range partition on disk, but a spilled
+            // counter cannot serve `entries()` -- and `correct_umis`, which the bindings run on
+            // these counters, needs every entry resident to walk each barcode's 3L neighbourhood.
+            // A plain range partition splits a barcode from its neighbour whenever the
+            // substitution falls in the partitioned bits, so correction has to become two passes
+            // with the key rotated (ROADMAP item 2) before this line can be switched on.
+            // Turning it on first would bound the memory and silently stop correcting.
         } else {
             file_of[i] = static_cast<uint32_t>(it - stats.sample_ids.begin());
             // The rows would otherwise write UMIs of two lengths into one counter, and the

--- a/src/umi_stats.cpp
+++ b/src/umi_stats.cpp
@@ -3,7 +3,10 @@
 #include <algorithm>
 #include <cmath>
 #include <array>
+#include <filesystem>
+#include <fstream>
 #include <numeric>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -186,15 +189,127 @@ void UmiCounts::flush() const {
     }
     buf_.clear();
     set_next_flush();
+    if (spill_budget_ && entries_.size() * sizeof(Entry) > spill_budget_) spill();
+}
+
+void UmiCounts::enable_spill(const std::string& directory, size_t budget_bytes, int bits) {
+    if (bits < 1 || bits > 20) {
+        throw MigecError("UmiCounts::enable_spill: bits must be in 1..20, got " +
+                         std::to_string(bits));
+    }
+    if (budget_bytes == 0) throw MigecError("UmiCounts::enable_spill: budget must be positive");
+    spill_dir_ = directory;
+    spill_budget_ = budget_bytes;
+    spill_bits_ = bits;
+    std::filesystem::create_directories(directory);
+}
+
+void UmiCounts::require_resident(const char* what) const {
+    if (!spill_paths_.empty()) {
+        throw MigecError(std::string("UmiCounts: ") + what +
+                         " needs every entry resident, but this counter has spilled to a range "
+                         "partition -- that is the point of spilling. Use for_each(), which "
+                         "streams one bucket at a time.");
+    }
+}
+
+// The top `spill_bits_` bits of the key decide the bucket, so buckets are key-ordered ranges and
+// concatenating them in index order is ascending key order.
+void UmiCounts::spill() const {
+    if (entries_.empty()) return;
+    const size_t n_buckets = size_t{1} << spill_bits_;
+    if (spill_paths_.empty()) {
+        spill_paths_.resize(n_buckets);
+        for (size_t b = 0; b < n_buckets; ++b) {
+            spill_paths_[b] =
+                (std::filesystem::path(spill_dir_) / ("umi_" + std::to_string(b) + ".bin")).string();
+        }
+    }
+    // entries_ is already sorted, so each bucket is one contiguous run: find the boundaries and
+    // append each run in one write rather than per entry.
+    const int shift = 64 - spill_bits_;
+    size_t i = 0;
+    while (i < entries_.size()) {
+        const uint64_t b = entries_[i].key >> shift;
+        size_t j = i;
+        while (j < entries_.size() && (entries_[j].key >> shift) == b) ++j;
+        std::ofstream out(spill_paths_[static_cast<size_t>(b)],
+                          std::ios::binary | std::ios::app);
+        if (!out) throw MigecError("UmiCounts: cannot write spill file " + spill_paths_[static_cast<size_t>(b)]);
+        out.write(reinterpret_cast<const char*>(entries_.data() + i),
+                  static_cast<std::streamsize>((j - i) * sizeof(Entry)));
+        if (!out) throw MigecError("UmiCounts: short write to " + spill_paths_[static_cast<size_t>(b)]);
+        i = j;
+    }
+    // Release the capacity, not just the size: shrinking to zero size while holding the array is
+    // exactly the allocation being bounded.
+    std::vector<Entry>().swap(entries_);
+    distinct_known_ = false;
+}
+
+void UmiCounts::for_each(const std::function<void(const Entry&)>& fn) const {
+    flush();
+    if (spill_paths_.empty()) {
+        for (const Entry& e : entries_) fn(e);
+        return;
+    }
+    // Anything added since the last spill is still resident and belongs in its bucket.
+    const int shift = 64 - spill_bits_;
+    std::vector<Entry> bucket;
+    for (size_t b = 0; b < spill_paths_.size(); ++b) {
+        bucket.clear();
+        std::ifstream in(spill_paths_[b], std::ios::binary);
+        if (in) {
+            in.seekg(0, std::ios::end);
+            const std::streamoff bytes = in.tellg();
+            in.seekg(0, std::ios::beg);
+            if (bytes > 0) {
+                bucket.resize(static_cast<size_t>(bytes) / sizeof(Entry));
+                in.read(reinterpret_cast<char*>(bucket.data()), bytes);
+                if (!in) throw MigecError("UmiCounts: short read from " + spill_paths_[b]);
+            }
+        }
+        for (const Entry& e : entries_) {
+            if ((e.key >> shift) == b) bucket.push_back(e);
+        }
+        if (bucket.empty()) continue;
+        // A key can appear once per spill plus once resident, so reduction happens HERE rather
+        // than at spill time -- which is what makes a spill O(1) per entry.
+        std::sort(bucket.begin(), bucket.end(),
+                  [](const Entry& a, const Entry& c) { return a.key < c.key; });
+        size_t w = 0;
+        for (size_t r = 0; r < bucket.size(); ++r) {
+            if (w > 0 && bucket[w - 1].key == bucket[r].key) {
+                bucket[w - 1].count += bucket[r].count;
+            } else {
+                bucket[w++] = bucket[r];
+            }
+        }
+        for (size_t k = 0; k < w; ++k) fn(bucket[k]);
+    }
+}
+
+size_t UmiCounts::distinct() const {
+    flush();
+    if (spill_paths_.empty()) return entries_.size();
+    if (!distinct_known_) {
+        uint64_t n = 0;
+        for_each([&n](const Entry&) { ++n; });
+        distinct_cache_ = n;
+        distinct_known_ = true;
+    }
+    return static_cast<size_t>(distinct_cache_);
 }
 
 void UmiCounts::merge(const UmiCounts& other) {
     other.flush();
+    other.require_resident("merge()");
     for (const Entry& e : other.entries_) add(e.key, e.count);
 }
 
 const uint32_t* UmiCounts::find(uint64_t key) const {
     flush();
+    require_resident("find()");
     auto it = std::lower_bound(entries_.begin(), entries_.end(), key,
                                [](const Entry& e, uint64_t k) { return e.key < k; });
     if (it == entries_.end() || it->key != key) return nullptr;
@@ -215,11 +330,11 @@ size_t index_of(const UmiCounts& counts, uint64_t key) {
 
 CoverageHistogram UmiCounts::histogram() const {
     CoverageHistogram h;
-    for (const Entry& e : entries()) {
+    for_each([&h](const Entry& e) {
         const int b = log2_bin(e.count);
         h.reads[static_cast<size_t>(b)] += e.count;
         h.units[static_cast<size_t>(b)] += 1;
-    }
+    });
     return h;
 }
 
@@ -228,14 +343,15 @@ UmiComposition UmiCounts::composition(bool weight_by_reads) const {
     c.length = length_;
     c.freq.assign(static_cast<size_t>(length_), {0.0, 0.0, 0.0, 0.0});
     double total = 0.0;
-    for (const Entry& e : entries()) {
+    const int L = length_;
+    for_each([&](const Entry& e) {
         const double w = weight_by_reads ? static_cast<double>(e.count) : 1.0;
-        for (int j = 0; j < length_; ++j) {
+        for (int j = 0; j < L; ++j) {
             const uint8_t code = static_cast<uint8_t>((e.key >> (62 - 2 * j)) & 3u);
             c.freq[static_cast<size_t>(j)][code] += w;
         }
         total += w;
-    }
+    });
     if (total > 0.0) {
         for (auto& row : c.freq) {
             for (double& v : row) v /= total;

--- a/tests/benchmark/test_checkout_speed.py
+++ b/tests/benchmark/test_checkout_speed.py
@@ -146,3 +146,57 @@ def test_peak_memory_does_not_track_input_size(corpus):
     overhead = s["peak_rss_bytes"] - s["umi_memory_bytes"]
     print(f"\n  non-counter RSS {overhead / 2**20:.0f} MB")
     assert overhead < 1 << 30, "buffers should be bounded by chunk size x threads"
+
+
+def _corpus_of(directory, reads):
+    """A shallow library of `reads` reads, one distinct barcode per 4 of them."""
+    path = directory / f"reads_{reads}.fq.gz"
+    rng = random.Random(0)
+    with gzip.open(path, "wt", compresslevel=1) as fh:
+        i = 0
+        while i < reads:
+            sample = list(TAGS)[(i // READS_PER_UMI) % 4]
+            umi = "".join(rng.choice("ACGT") for _ in range(12))
+            payload = "".join(rng.choice("ACGT") for _ in range(90))
+            for _ in range(READS_PER_UMI):
+                seq = ("AA" + TAGS[sample] + ADAPTER + umi[:4] + "T" + umi[4:8] + "T" + umi[8:]
+                       + payload)
+                fh.write(f"@r{i}\n{seq}\n+\n{'I' * len(seq)}\n")
+                i += 1
+    (directory / "barcodes.txt").write_text(BARCODES)
+    return path
+
+
+@pytest.mark.xfail(reason="roadmap item 1: the counters are not partitioned yet", strict=True)
+def test_the_counters_do_not_grow_with_the_library(tmp_path):
+    """The one unbounded allocation left in the pipeline, stated as something that can fail.
+
+    Everything else in `checkout` is bounded by chunk x threads. The UMI counters are not: ~22 B
+    per DISTINCT barcode held in one piece, which is 8.8 GB at NovaSeq scale. A warning past 1 GB
+    reports the problem rather than fixing it.
+
+    Never: assert a SCALING property, not a fixed budget. A budget test passes vacuously at any
+    corpus small enough to run in CI -- 50,000 barcodes is 1 MB, under any threshold worth naming,
+    so the test would go green while the term it exists to bound grew without limit. Doubling the
+    distinct barcodes and watching what the counters do is the question that has the same answer at
+    every scale.
+
+    Never: the fix is the range partition, not a smaller struct. 16 B per entry is already near the
+    floor for (key, count); shaving it buys a constant factor against a term that grows without
+    limit, which is the wrong axis.
+    """
+    from migec.checkout import run
+
+    small = run(_corpus_of(tmp_path, 100_000), tmp_path / "barcodes.txt", tmp_path / "a", threads=4)
+    large = run(_corpus_of(tmp_path, 400_000), tmp_path / "barcodes.txt", tmp_path / "b", threads=4)
+
+    def distinct(s):
+        return sum(x["umis"] for x in s["samples"])
+
+    growth = large["umi_memory_bytes"] / max(small["umi_memory_bytes"], 1)
+    print(f"\n  {distinct(small):,} barcodes: {small['umi_memory_bytes'] / 2**20:6.1f} MB"
+          f"\n  {distinct(large):,} barcodes: {large['umi_memory_bytes'] / 2**20:6.1f} MB"
+          f"  ({growth:.2f}x for {distinct(large) / distinct(small):.2f}x the barcodes)")
+    assert growth < 1.5, (
+        f"4x the distinct barcodes cost {growth:.2f}x the counter memory -- still one piece, "
+        f"still growing with the library")

--- a/tests/cpp/test_umi_stats.cpp
+++ b/tests/cpp/test_umi_stats.cpp
@@ -1,6 +1,7 @@
 #include "doctest.h"
 
 #include <algorithm>
+#include <filesystem>
 #include <random>
 #include <string>
 
@@ -489,4 +490,95 @@ TEST_CASE("barcode base quality sharpens the error prior") {
     };
     CHECK_FALSE(merged_with(1e-6f));  // a confident base is not a miscall
     CHECK(merged_with(0.3f));         // Q5 at exactly the base that differs
+}
+
+// --- spilling: the range partition that bounds the counters (roadmap item 1) -----------------
+
+TEST_CASE("a spilled counter answers exactly as a resident one") {
+    // The whole claim: partitioning changes the memory, never the numbers. Both counters see the
+    // same adds in the same order; one is forced to spill many times over.
+    std::mt19937_64 rng(12345);
+    std::vector<std::pair<uint64_t, uint32_t>> adds;
+    for (int i = 0; i < 20000; ++i) {
+        std::string s;
+        for (int j = 0; j < 8; ++j) s += "ACGT"[rng() % 4];
+        adds.emplace_back(umi(s), static_cast<uint32_t>(1 + rng() % 5));
+    }
+
+    UmiCounts resident(8);
+    UmiCounts spilling(8);
+    const std::string dir =
+        (std::filesystem::temp_directory_path() / "migec_spill_test").string();
+    std::filesystem::remove_all(dir);
+    // A tiny budget so it spills repeatedly: a key ends up written to its bucket many times over,
+    // which is the case reduction-on-read has to get right.
+    spilling.enable_spill(dir, 4096, 4);
+    for (const auto& a : adds) {
+        resident.add(a.first, a.second);
+        spilling.add(a.first, a.second);
+    }
+
+    CHECK(spilling.spilled());
+    CHECK(spilling.total() == resident.total());
+    CHECK(spilling.distinct() == resident.distinct());
+
+    const CoverageHistogram hr = resident.histogram();
+    const CoverageHistogram hs = spilling.histogram();
+    CHECK(hs.reads == hr.reads);
+    CHECK(hs.units == hr.units);
+    CHECK(hs.mean_reads_per_umi() == doctest::Approx(hr.mean_reads_per_umi()));
+
+    const UmiComposition cr = resident.composition(false);
+    const UmiComposition cs = spilling.composition(false);
+    REQUIRE(cs.length == cr.length);
+    for (int j = 0; j < cr.length; ++j) {
+        for (int b = 0; b < 4; ++b) {
+            CHECK(cs.freq[static_cast<size_t>(j)][static_cast<size_t>(b)] ==
+                  doctest::Approx(cr.freq[static_cast<size_t>(j)][static_cast<size_t>(b)]));
+        }
+    }
+    CHECK(cs.effective_length() == doctest::Approx(cr.effective_length()));
+
+    // for_each must still deliver ascending keys, each exactly once: the range partition is
+    // ordered by construction and everything downstream assumes it.
+    std::vector<uint64_t> keys;
+    spilling.for_each([&keys](const UmiCounts::Entry& e) { keys.push_back(e.key); });
+    CHECK(keys.size() == resident.distinct());
+    CHECK(std::is_sorted(keys.begin(), keys.end()));
+    CHECK(std::adjacent_find(keys.begin(), keys.end()) == keys.end());
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("a spilled counter refuses the accessors that need every entry") {
+    // Never: silently returning the resident remainder would be a wrong answer wearing the shape
+    // of a right one -- `find()` would report "absent" for a barcode that is merely spilled.
+    const std::string dir =
+        (std::filesystem::temp_directory_path() / "migec_spill_refuse").string();
+    std::filesystem::remove_all(dir);
+    UmiCounts c(8);
+    c.enable_spill(dir, 64, 3);
+    // Past the internal flush threshold: a spill happens on flush, so a handful of adds sit in the
+    // buffer and never reach the partition at all.
+    std::mt19937_64 rng(7);
+    for (int i = 0; i < 20000; ++i) {
+        std::string s;
+        for (int j = 0; j < 8; ++j) s += "ACGT"[rng() % 4];
+        c.add(umi(s), 1);
+    }
+    c.distinct();  // forces the flush, and with it the spill
+    REQUIRE(c.spilled());
+    CHECK_THROWS_AS(c.entries(), MigecError);
+    CHECK_THROWS_AS(c.find(umi("AAAAAAAA")), MigecError);
+    // ...but the streaming ones still work, which is the point.
+    CHECK(c.distinct() > 0);
+    CHECK(c.histogram().units[0] > 0);
+    std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("enable_spill validates its arguments where they are attributable") {
+    UmiCounts c(4);
+    CHECK_THROWS_AS(c.enable_spill("/tmp/migec_bad", 1024, 0), MigecError);
+    CHECK_THROWS_AS(c.enable_spill("/tmp/migec_bad", 1024, 21), MigecError);
+    CHECK_THROWS_AS(c.enable_spill("/tmp/migec_bad", 0, 4), MigecError);
 }


### PR DESCRIPTION
Roadmap item 1, as far as it goes before item 2 blocks it.

## The problem, stated as a test

`checkout`'s UMI counters were the only allocation in the pipeline that grows with the *library*
rather than with the chunk: ~22 B per distinct barcode held in one piece, 8.8 GB at NovaSeq scale.
A warning past 1 GB reported it rather than fixing it. There was no test.

There is now, and it fails on master: **3.91x the counter memory for 4.00x the distinct barcodes.**

**Never: assert a scaling property, not a fixed budget.** My first version compared
`umi_memory_bytes` against 64 MB and passed vacuously — 50,000 barcodes is 1 MB, under any
threshold that fits in CI, so it would have gone green while the term it exists to bound grew
without limit.

## What landed

`UmiCounts::enable_spill()` range-partitions to disk past a byte budget; `for_each()` streams one
bucket at a time. `histogram()`, `composition()` and `distinct()` are written against it and give
byte-identical answers spilled or resident.

- **Range, never hash** — same rule as `assemble`'s partition. Nothing that streams today needs a
  barcode and its neighbours to meet, but a hash would make the correction pass impossible to add.
- **A spilled counter refuses `entries()`, `find()`, `merge()`** rather than answering from what is
  still in RAM. `find()` would otherwise report "absent" for a barcode that is merely spilled.
- **Reduction on read, not on write** — a key is written once per spill, so a spill stays O(1) per
  entry. A test spills repeatedly at a 4 kB budget to exercise exactly that.

## What did not land, and why

The call site in `checkout` is written and **commented out**. The bindings run `correct_umis` on
these counters, and correction walks each barcode's 3L neighbourhood — which a plain range
partition splits whenever the substitution lands in the partitioned bits. Switching the spill on
first would bound the memory and *silently stop correcting*.

So roadmap items 1 and 2 are one item, and the rotated-key pass comes first. The roadmap now says
so instead of listing them as independent work.

## Verification

107 C++ tests (224k assertions), 116 Python unit tests, ruff clean, docs build under `-W`. The
benchmark test stays `xfail(strict=True)` — it flips to passing when the spill is switched on,
which is the signal that item 1+2 is actually done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)