### PR TITLE
2.4.0 — nothing scales with the library, and the comparisons start landing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ Hand-written and prose-heavy: each entry says what changed and, where it matters
 prevents. Releases before 2.0.0 are the Groovy MIGEC and are described by their git tags on the
 `legacy-v1` branch.
 
-## Unreleased
+## 2.4.0 — 2026-08-14
+
+**Nothing in the pipeline scales with the library any more**, and the comparisons the version
+number was waiting on have started landing: MIGEC 1.2.9, UMI-tools and fgbio are all run end to
+end and scored.
+
+Note: 2.3.0 was written up but never tagged or published — the last wheel on PyPI is 2.2.1 — so
+this release carries its changes too. Its section below still describes them.
 
 ### MIGEC 1.2.9, head to head
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath("../python"))
 project = "migec"
 copyright = "2026, Mikhail Shugay"
 author = "Mikhail Shugay"
-release = "2.3.0"
+release = "2.4.0"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/include/migec/version.hpp
+++ b/include/migec/version.hpp
@@ -4,6 +4,6 @@
 // Kept in sync by hand with pyproject.toml and python/migec/__init__.py. The release checklist in
 // CLAUDE.md lists all three; CI prints them so a mismatch is visible before a release, and
 // publish.yml asserts the pyproject version equals the release tag.
-#define MIGEC_VERSION "2.3.0"
+#define MIGEC_VERSION "2.4.0"
 
 #endif  // MIGEC_VERSION_HPP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "migec"
-version = "2.3.0"  # keep in sync with include/migec/version.hpp and python/migec/__init__.py
+version = "2.4.0"  # keep in sync with include/migec/version.hpp and python/migec/__init__.py
 description = "UMI barcode extraction, correction and consensus assembly for barcoded sequencing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/migec/__init__.py
+++ b/python/migec/__init__.py
@@ -5,7 +5,7 @@ fallback, because a fallback would make a failed C++ build look like a successfu
 surface forty minutes into a run.
 """
 
-__version__ = "2.3.0"  # keep in sync with pyproject.toml and include/migec/version.hpp
+__version__ = "2.4.0"  # keep in sync with pyproject.toml and include/migec/version.hpp
 
 from migec import _core
 from migec._core import (


### PR DESCRIPTION
Release PR for 2.4.0. Version bumped in all four places; every gate green locally (ctest, 316 pytest, ruff, sphinx `-W`).

**2.3.0 was written up but never tagged or published** — the last wheel on PyPI is 2.2.1 — so this wheel carries its changes too.

## What is in it

**`refine`'s barcode table bounds itself.** The last thing in the pipeline that scaled with the library. Past 1 GB the table range-partitions to disk and correction follows it in two passes with the key rotated; a partitioned run and a resident one agree on every scalar and every output file byte for byte.

Two things this needed that `checkout`'s counters did not: the table carries the **evidence** (a side array indexed against the entry list cannot survive a partition, and dropping it leaves the run correcting on the count ratio alone, which reports nothing at 1–3 reads per UMI), and the two passes **scan** rather than merge, with one global apply — a barcode can have a plausible parent on each side of the boundary, and merging inside a pass takes the first candidate rather than the best.

**MIGEC 1.2.9, head to head.** 9.4–11.9× the wall clock against an M5 gate of 3×, 3.5–3.7× less memory, molecule count 0.09% over truth against v1's 13.6%.

**UMI-tools and fgbio, scored.** On one reference migec wins — ARI 0.9967 against 0.9864 and 0.9817, with 4.6× and 6× fewer molecules destroyed. On a diverse reference they win by 0.001 ARI, and that gap is a measured depth threshold: `assemble` separates 0/12 collisions at 9.1 reads on the barcode and 10/10 by 82.

**Three memory bugs** the benchmark tier caught in the new table. refine is 1.88 M reads/s, up from 1.55 M, at lower peak RSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)