### PR TITLE
The wheel smoke test lowercased the sample id along with the adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ prevents. Releases before 2.0.0 are the Groovy MIGEC and are described by their 
 
 ## 2.4.0 — 2026-08-14
 
+Note: the wheel smoke test lowercased the whole barcode-sheet line, sample id included, so
+`checkout` wrote `co/s1.fq.gz` and the next command asked for `co/S1.fq.gz`. That passes on macOS,
+whose filesystem is case-insensitive, and fails on Linux — and 2.4.0 is the first release whose
+publish run executed the script at all, so it failed there and nowhere else. The adapter is
+lowercased on its own now.
+
 **Nothing in the pipeline scales with the library any more**, and the comparisons the version
 number was waiting on have started landing: MIGEC 1.2.9, UMI-tools and fgbio are all run end to
 end and scored.

--- a/scripts/wheel_smoke.sh
+++ b/scripts/wheel_smoke.sh
@@ -25,7 +25,11 @@ adapter=CAGTGGTATCAACGCAGAGT
     printf '@r%s\n%s\n+\n%s\n' "$i" "ACGTACGT${adapter}TTTTCCCCGGGGAAAA" "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII"
   done
 } > reads.fq
-printf 'S1\t%s\n' "NNNNNNNN${adapter}" | tr 'A-Z' 'a-z' | sed 's/nnnnnnnn/NNNNNNNN/' > bc.txt
+# Never: lowercase the ADAPTER only. Lowercasing the whole line lowercases the sample id too, so
+# checkout writes `co/s1.fq.gz` and the next line asks for `co/S1.fq.gz` -- which passes on macOS,
+# whose filesystem is case-insensitive, and fails on Linux. It failed exactly once, in the 2.4.0
+# publish run, on the first release that ran this script at all.
+printf 'S1\t%s\n' "NNNNNNNN$(printf '%s' "$adapter" | tr 'A-Z' 'a-z')" > bc.txt
 
 migec checkout reads.fq -b bc.txt -o co
 migec refine co/S1.fq.gz -o re


### PR DESCRIPTION
Blocks the 2.4.0 publish. `tr 'A-Z' 'a-z'` was applied to the whole barcode-sheet line, so the sample id became `s1` and `checkout` wrote `co/s1.fq.gz` while the next command asked for `co/S1.fq.gz`.

macOS has a case-insensitive filesystem and never noticed. Linux does not — and 2.4.0 is the first release whose publish run executed this script at all, so it failed on the Linux wheel job only, with the release already tagged and nothing published.

The adapter is lowercased on its own now, and the `sed` that put the N run back is gone with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)