### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,178 @@ prevents. Releases before 2.0.0 are the Groovy MIGEC and are described by their 
 
 ## Unreleased
 
+## 2.5.0 — 2026-08-15
+
+### The knee is Kneedle, and it now refuses to answer when there is no knee
+
+`refine`'s cell-calling knee was already the right rule and is now documented as such: distance to
+the endpoint chord of the log-log curve **is** Kneedle's (Satopaa 2011) normalised
+`|y_n - (1 - x_n)|` up to a constant, taken at its **global maximum**.
+
+Never: **Kneedle's published selection rule is degenerate without the smoothing spline the paper
+specifies.** It walks the LOCAL maxima and stops at the first that then falls by a sensitivity
+step. Measured on `sc5p_v2_hs_PBMC_1k`'s 136,032 barcodes: unsmoothed, the difference curve has
+**287 local maxima and the walk stops at rank 15 (1,057 molecules)** — fifteen cells. Smoothed
+over a 0.01 window in normalised log-rank it gives rank 358 (314 molecules), which is the global
+maximum's rank 376 (308 molecules) to within 5%; over-smoothing drifts it back off (rank 180 at a
+0.1 window). The global maximum lands in the same place with no parameter to tune.
+
+Never: **a global maximum always exists, so the knee needs a floor.** An ambient-only library
+returns a rank too, and reporting it beside OrdMag reads as two methods disagreeing about where
+the cells are rather than as a curve with no cells in it. The knee is refused below **ten times
+the mean molecules per observed barcode** — one order of magnitude, the unit a log-log curve is
+read in — and `knee_rank` is then 0, which the report prints as "no knee" and the
+OrdMag-vs-knee warning already skips.
+
+Never: **the mean alone is too weak and was tried.** An ambient-only library of 1-3 molecules per
+barcode is a step curve whose corner sits at 3 against a mean of 2.0 and clears a mean-only test
+at 1.5x. On the real library the knee is 308 against a mean of 3.38, a factor of 91 — two orders
+apart, so the boundary is not a tuned one. Both cases are in
+`tests/synthetic/test_refine.py`.
+
+arda implements the same rule in `arda.singlecell.find_knee` for its own rank curve, and the two
+agree exactly on the same 136,032-barcode curve: rank 376, 308 molecules.
+
+### Reference-free per-cell contigs, and doublets
+
+`scripts/compare_cellranger_contigs.py`, `assets/cellranger_contigs.tsv`, `docs/single_cell.rst`.
+The assembler itself is **arda's** — `arda cells` — because a cell's full-length receptor,
+doublets and contaminating chains are arda's job and always were; migec's `--contig` stays one
+molecule's fragments and nothing more.
+
+**The premise was measured before the method was written.** Reads of one `(cell, UMI)` are
+co-terminal, so a molecule's consensus covers one window of the transcript however deep it is —
+at `--min-reads 30` the mean is 204 nt against a ~508 nt amplicon. But *different molecules start
+at different positions*, so a cell's molecules tile it: **99.90% of the 25-mers of Cell Ranger's
+943 filtered contigs are already in their own cell's raw migec molecules**, with 942 of 943 CDR3
+nucleotide sequences appearing verbatim. The contig was in the data; assembling it was an
+engineering problem, not an information one.
+
+| variant | k-mer coverage | CDR3 exact | N50 | chain recall | doublets |
+|---|---|---|---|---|---|
+| molecules, no assembly (ceiling) | 0.9990 | 942/943 | — | — | — |
+| `arda cells`, default | **0.9759** | **933/943 (0.9894)** | 536 | **0.9777** | 17 |
+| no phasing | 0.9663 | 926/943 (0.9820) | 460 | 0.9714 | 12 |
+| no adapter trim | 0.9525 | 907/943 (0.9618) | 580 | 0.9491 | 16 |
+
+Per chain: **TRA 454/464, TRB 479/479**. 479 cells, 249,635 molecules, 23 s.
+
+Never: **`--min-reads 1` on this axis.** A one-read molecule is a poor consensus and one more
+window of the transcript, and the assembly needs the second thing. A depth cut throws the tiling
+away.
+
+Never: **contig N50 is a description, never a score.** The no-adapter-trim row has the highest
+N50 in the table and the lowest value in every other column.
+
+Never: **a doublet is two chains of the same LOCUS, and it was invisible by construction until
+the phasing landed.** One TRA and one TRB is a paired T cell. Two TRB share their constant
+region, so the overlap layout puts them in one component and the column consensus averages their
+junctions into a third sequence — on a synthetic cell built from two TRB receptors, one 918 nt
+contig with no callable junction. Phasing the component on co-segregating minor bases recovers
+both.
+
+Never: **the extra-chain gate is PRODUCTIVITY first, count second.** Of the extra chains Cell
+Ranger agrees with, 60/60 are productive; of those it does not, 20/128 are. An extra chain on
+exactly one molecule is contamination 96-97% of the time — the distribution is bimodal, not a
+tail.
+
+### Cell Ranger, and the counter bug it found
+
+The last unrun comparator. `scripts/compare_cellranger.py` scores migec against **Cell Ranger
+5.0.0** on `sc5p_v2_hs_PBMC_1k` VDJ-T, both lanes, 6,301,573 read pairs. `assets/cellranger.tsv`,
+`docs/single_cell.rst`.
+
+| tool | valid barcode | cells | shared | reads in cells | wall | peak RSS |
+|---|---|---|---|---|---|---|
+| Cell Ranger 10.1.0 | **90.60%** | 478 | 469 | **86.40%** | 524.5 s | 936 MB |
+| migec, 737K whitelist | 88.90% | 888 | 469 | 84.88% | **35.0 s** | **679 MB** |
+
+**migec calls 1.86x the cells and loses 1.5 points of reads-in-cells.** The 419 barcodes beyond
+Cell Ranger's set hold about one and a half percent of the library between them, so a cell count on
+its own is not an accuracy figure — which is the point of reporting the two together.
+
+**Cell Ranger is run twice: 10x's published 5.0.0 calls, and `cellranger vdj` 10.1.0 run here**
+(`scripts/cellranger_vdj.sbatch`, 16 cores on aldan3). They agree at **Jaccard 0.9938** — 477 cells
+shared of 479 and 478 — which is the control that says the migec gap is not version drift.
+
+Never: **35 s against 524 s is not like for like.** Cell Ranger's single invocation also assembles
+and annotates a contig per cell; migec's 35 s is `checkout` + `refine`, which is what answers these
+three axes. End to end with `assemble --contig` and arda it is ~90 s, still 5.8x, and it produces
+per-*molecule* resolution Cell Ranger's output does not have. Different hardware, so read the ratio.
+
+Never: **5.0.0's published `Median TRB UMIs per Cell` of 12.0 matches neither denominator in its own
+tables** — both give 11.0. 10.1.0 reports TRA 4.0 / TRB 11.0, which are exactly the medians over
+*all* cells in its tables, while 5.0.0's TRA 5.0 is the median over cells that *have* that chain.
+Running the second version is what turned "not recoverable" into "wrong, and here is why".
+
+Never: **the two cell sets are not the same population.** migec's gate is molecules of any
+sequence; Cell Ranger's is "assembled a productive V(D)J contig", so a B cell with plenty of
+molecules is correctly a migec cell and correctly not a Cell Ranger VDJ cell. The table carries
+five counts and never a ratio.
+
+Never: **`checkout` keyed its UMI counters on the UMI alone**, which merged every cell's copy of
+one UMI into a single entry — against this repo's own rule that a molecule is sample + cell + UMI.
+On this library it read 221,026 pooled UMIs where there are 311,962 molecules, put the depth 1.41x
+high, and fired the saturation warning at an apparent 21% occupancy against a true 3e-6. The key is
+now cell then UMI. `CheckoutStats::sample_cell_length` splits the composition back apart, so the
+summary reports `cell_length`, `umi_length` and `barcode_length` separately rather than letting
+`umi_length` quietly become 26 for a 10 nt UMI.
+
+Never: **splitting the length apart leaves every consumer that paired it with a barcode-wide
+statistic comparing two different units.** `effective_length` is a property of the counter, so it
+spans 26 nt on a 10x run; weighed against the 10 nt UMI the composition-skew warning reads "25.4
+of 10 nt usable", which cannot be true, and it was therefore dead on every single-cell library --
+exactly where a skewed cell barcode is worth hearing about. It is weighed against
+`barcode_length` now. `checkout.summary.tsv` carries all three lengths as columns (inserted after
+`umi_length`, so the sample/reads/UMIs columns the plots read do not move), and
+`checkout.barcode_space.tsv`'s second column is renamed `umi_length` -> `barcode_length`, which
+is what its value always was. Regression test in `tests/synthetic/test_dual_end.py`: a cell
+barcode with eight constant positions gives 17.93 usable bases of 26, which fires the warning and
+would not have fired the old one.
+
+Never: **`docs/formats.rst` documented a consensus read name the code does not write.** It gave a
+colon-delimited `@<sample>.<mig>[.<g>]:<CB>:<UMI>`; `assemble` writes
+`<sample>[.<cell>].<umi>[.c<k>][.<m>]`, dot-delimited, with both suffixes emitted conditionally.
+Anything parsing that name must read it from the **right**, since a sample id may contain a dot.
+
+### The per-cell chain axis, and a 19.7x speedup in `--contig`
+
+`scripts/compare_cellranger_chains.py`, `assets/cellranger_chains.tsv`. Cell Ranger assembles a
+contig per **cell**; migec assembles a consensus per **molecule**, annotates each with arda
+(`--cell-from migec`), and votes per cell. Same question, no per-cell assembler.
+
+| locus | Cell Ranger chains | migec chains | shared | chain recall | junction agreement |
+|---|---|---|---|---|---|
+| TRA | 426 | 451 | 426 | **1.0000** | 0.9507 |
+| TRB | 469 | 474 | 468 | **0.9979** | **0.9915** |
+
+**Every TRA chain and all but one TRB chain Cell Ranger found is recovered**, in 22 s over 47,584
+consensuses. Recall leads because a missed chain is the unrecoverable error; junction agreement is
+scored only over chains both tools called, which is a self-selecting denominator.
+
+**`place_reads` asks union-find before it scans: 640.9 s -> 32.6 s on that run, byte-identical
+output** (consensus FASTQ and `mig.tsv` both MD5-identical, 47,584 molecules unchanged). The O(n²)
+pair loop was calling `seed_offset` on every pair, and `join` already returns immediately when the
+two roots match -- so on a deep group most of those scans computed something union-find knew.
+Never: this is not a heuristic and not a cap on reads; it is the same partition reached without the
+redundant comparisons, which is why the output does not move.
+
+Note: **the stale `ponytail:` comment beside it was the tell, and it was wrong in a specific way.**
+It said the quadratic ran "over single digits" because X1 measured only 1.5% of 10x groups holding
+more than one read -- true of *all* groups, false of the ones contig mode is run on. At
+`--min-reads 30` the molecules average 110 reads and the deepest holds 802.
+
+Note: **breaking out of the loop once one component holds every read was also tried and is not
+kept.** It is exact, and it measured 33.4 s against 32.6 -- nothing, because what remains after the
+short-circuit is path-compressed `find` calls at a few nanoseconds. Three lines that bound a
+worst case no benchmark asks for.
+
+Note: **depth does not buy junction coverage on this chemistry, and the obvious arithmetic says it
+does.** Reads of one `(CB, UMI)` are co-terminal in 92% of 10x groups, so a molecule is a pile at
+one position, not a tiling: at `--min-reads 30` the mean consensus is **204 nt, not 508**, and
+7,855 of 47,584 molecules (16.5%) carry a cell, a locus and a junction — near the single-window
+0.32 the geometry predicts, and nowhere near the 0.975 a per-read-uniform model gives.
+
 ### What migec is worth downstream, measured against certified material
 
 The comparisons the version number was waiting on. All of them run on commercial cfDNA reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,6 +642,106 @@ rebuild the old tag.
   negatives included.
 - **The cluster jobs `SOURCES.md` cited are committed** as `scripts/ctdna_{infer_panel,per_site,minreads}.sbatch`.
   A `Regenerate` cell naming a file nobody has is not provenance.
+- **Cell Ranger is done (2026-08-14), and it found a bug in our own counter.**
+  `scripts/compare_cellranger.py`, `assets/cellranger.tsv`, `docs/single_cell.rst`. On
+  `sc5p_v2_hs_PBMC_1k` VDJ-T, both lanes: migec calls **888 cells against Cell Ranger's 479**,
+  sharing 470, and **loses 1.9 points of reads-in-cells (84.88% against 86.80%)** -- so the 418
+  extra barcodes are nearly empty and a cell count on its own is not an accuracy figure. Barcode
+  validity 88.90% against 90.60%. Never: **Cell Ranger is NOT re-run** -- it is Linux x86_64 and
+  licence-gated, so the comparator is 10x's own published output and there is no cost column.
+  Never: **the two cell sets are not the same population** (molecules of any sequence against
+  "assembled a productive V(D)J contig"), so the table carries five counts and never a ratio.
+  Never: **`checkout` keyed its UMI counters on the UMI ALONE** until this run --
+  `w.umis.emplace_back(s, umi_key)` -- which merged every cell's copy of one UMI. On this library
+  that read 221,026 pooled UMIs where there are 311,962 molecules, put the depth 1.41x high, and
+  fired the saturation warning at an apparent 21% occupancy against a true 3e-6. Fixed: the key is
+  now cell then UMI, `cell_key | (umi_key >> 2*cell_len)`, which is `pack_barcode(cell + umi)`
+  without the allocation. `CheckoutStats::sample_cell_length` splits the composition back into
+  `cell_length` / `umi_length` / `barcode_length`, because the counter's length is the barcode's
+  and `umi_length` must not quietly become 26 for a 10 nt UMI.
+- **Cell Ranger 10.1.0 was RUN, on aldan3, and the cost axis exists (2026-08-14).** It is not
+  licence-gated in any way that blocks us: `scripts/cellranger_vdj.sbatch`, 16 cores, 8m44s,
+  936 MB peak, under **`/projects/immunestatus`** -- never `/projects/cdr3*`, which is read-only for
+  us (global rule). aria2c `-x8` pulls the 932 MB tarball at 4.3 MB/s where a plain `curl` stalled
+  at 50 MB; the V(D)J reference is germline only, 3.2 MB, not a genome. Never: **the version is a
+  COLUMN in both assets** -- 5.0.0 (10x's published calls) and 10.1.0 agree at **Jaccard 0.9938**,
+  477 cells shared of 479/478, which is the control saying the migec gap is not version drift.
+  Never: **35.0 s against 524.5 s is not like for like** -- Cell Ranger also assembles and annotates
+  a contig per cell, so the comparable end-to-end row is checkout+refine+assemble+arda at ~90 s,
+  still 5.8x, on different hardware, so quote the ratio and not the seconds.
+- **Never: Cell Ranger 5.0.0's published `Median TRB UMIs per Cell` is wrong, not merely
+  differently defined.** It says 12.0; both denominators over its own deposited tables give 11.0.
+  10.1.0 reports TRA 4.0 / TRB 11.0, which are exactly the medians over ALL cells in its tables,
+  while 5.0.0's TRA 5.0 is the median over cells that HAVE that chain. Running the second version
+  is what turned "not recoverable from the tables" into "wrong, and here is the denominator".
+- **The per-cell chain axis is done and migec plus arda match the assembler (2026-08-14).**
+  `scripts/compare_cellranger_chains.py`, `assets/cellranger_chains.tsv`. Cell Ranger assembles a
+  contig per CELL; migec assembles a consensus per MOLECULE, arda annotates each
+  (`--cell-from migec`), and the cell's chain is a vote over its molecules. **TRA 426/426 recall,
+  TRB 468/469**, junction agreement 0.9507 / 0.9915, 22 s over 47,584 consensuses, no per-cell
+  assembler anywhere. Never: **recall leads, concordance follows** -- concordance is scored over
+  the chains BOTH tools called, a self-selecting denominator that reads high whatever happens.
+  Never: **arda runs `rnaseq --exact`, never `amplicon`** -- that preset turns on `two_pass`,
+  `fast_segments` and `segment_only_v`, which assume a primer-anchored read spanning V into J, and
+  these are 90 nt tiles of a fragmented amplicon.
+- **The knee is Kneedle at its GLOBAL maximum, and it refuses when there is no knee
+  (2026-08-15).** Distance to the endpoint chord of the log-log curve IS Kneedle's normalised
+  `|y_n - (1 - x_n)|` up to a constant; only the selection rule differs. Never: **Kneedle's
+  published rule -- walk the LOCAL maxima, stop at the first that falls by a sensitivity step --
+  is degenerate without the paper's smoothing spline.** On 136,032 barcodes the unsmoothed
+  difference curve has **287 local maxima and the walk stops at rank 15 (1,057 molecules)**, i.e.
+  fifteen cells; smoothed at a 0.01 log-rank window it gives rank 358, the global maximum's 376
+  to within 5%, and over-smoothing drifts it off again (180 at 0.1). The global maximum needs no
+  smoothing parameter. Never: **a global maximum always exists, so guard it** -- the knee is
+  refused below **10x the mean molecules per observed barcode**, and `knee_rank` is then 0.
+  Never: **the mean alone is too weak and was tried** -- an ambient-only 1-3 molecule library is a
+  step curve whose corner is 3 against a mean of 2.0 (1.5x, passes), where the real library is 308
+  against 3.38 (91x). Two orders apart, so the boundary is not tuned. `arda.singlecell.find_knee`
+  is the same rule and agrees exactly: rank 376, 308 molecules.
+- **Reference-free per-cell contigs are done, in ARDA, and they nearly match the assembler
+  (2026-08-15).** `scripts/compare_cellranger_contigs.py`, `assets/cellranger_contigs.tsv`,
+  `arda cells`. **933/943 of Cell Ranger's CDR3s recovered verbatim (0.9894), TRA 454/464, TRB
+  479/479**, k-mer coverage 0.9759, N50 536 nt, chain recall 0.9777, 479 cells in 23 s, with no
+  germline reference read until the finished contigs are annotated. The assembler is arda's
+  because the non-negotiable above says so; migec's `--contig` stays one molecule's fragments.
+  Never: **the premise was measured before the method was written** -- 99.90% of the 25-mers of
+  Cell Ranger's 943 contigs are ALREADY in their own cell's raw molecules (942/943 CDR3s
+  verbatim), because different molecules start at different positions even though each covers one
+  window. That ceiling row is in the table and every method row is scored against it.
+  Never: **`--min-reads 1` here.** A one-read molecule is a poor consensus and one more window of
+  the tiling, and the tiling is what the assembly needs. The depth cut belongs to the
+  per-molecule route, not this one.
+  Never: **contig N50 is a description, never a score** -- the no-adapter-trim ablation has the
+  HIGHEST N50 (580 against 536) and the lowest value in every other column.
+  Never: **a doublet is two chains of the same LOCUS and it was invisible by construction** until
+  component phasing landed: two TRB share their constant region, so the layout merges them and the
+  column consensus averages their junctions into a third sequence (one 918 nt contig, no callable
+  junction, on a synthetic two-TRB cell). Worth 0.9714 -> 0.9777 and 12 -> 17 doublet candidates.
+  Never: **the extra-chain gate is PRODUCTIVITY first, count second** -- 60/60 of the extra chains
+  Cell Ranger agrees with are productive against 20/128 of those it does not, and an extra chain
+  on exactly one molecule is contamination 96-97% of the time. Bimodal, not a tail.
+- **Never: depth does not buy junction coverage on a co-terminal chemistry, and the obvious
+  arithmetic says it does.** Placing each read uniformly over the ~508 nt amplicon gives
+  P(span the 42 nt junction) = 0.114 per read and 0.975 at 30 reads. Measured, false: reads of one
+  `(CB, UMI)` are co-terminal in 92% of 10x groups, so a molecule is a **pile at one position**,
+  not a tiling, and its consensus covers one window however deep. At `--min-reads 30` the mean
+  consensus is **204 nt, not 508**, and **7,855 of 47,584 molecules (16.5%)** carry a cell, a locus
+  and a junction -- near the single-window 0.32 the geometry predicts. The depth cut still earns
+  its place, because a deep pile gives a clean consensus; it just does not extend one.
+- **`--contig` is 19.7x faster and byte-identical (2026-08-14): 640.9 s -> 32.6 s** on 47,584
+  molecules. `place_reads` ran an O(n^2) pair loop calling `seed_offset` on every pair, and `join`
+  already returns immediately when the two roots match -- so ask union-find FIRST and skip the seed
+  scan. Exact, not a heuristic: the pairs skipped are the ones whose answer `join` discarded, which
+  is why the consensus FASTQ and `mig.tsv` are MD5-identical. Never: **the stale `ponytail:`
+  comment beside it was the tell** -- it said the quadratic ran "over single digits" from X1's
+  "1.5% of 10x groups hold more than one read", which is true of ALL groups and false of the ones
+  contig mode runs on (110 reads mean, 802 deepest). Note: breaking out entirely once one component
+  holds every read is also exact and measured **33.4 s against 32.6, i.e. nothing** -- not kept.
+- **Never: `docs/formats.rst` documented a consensus name the code does not write.** It said
+  `@<sample>.<mig>[.<g>]:<CB>:<UMI>`; `src/assemble.cpp:501-511` writes
+  `<sample>[.<cell>].<umi>[.c<k>][.<m>]`, dot-delimited with no colon anywhere and with both
+  suffixes emitted conditionally. Anything parsing the name must read it **from the right** -- a
+  sample id may itself contain a dot. Corrected.
 - **Next, in order. `ROADMAP.md` has the same list with the reasoning; this is the short form.**
   1. **`2026-migec-benchmark`** and the published comparisons. This is what the version number is
      waiting on, not the code.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ Everything below is either open or half-open. Nothing else on this page is.
 | # | item | milestone | why it is next |
 |---|---|---|---|
 | 1 | The RT-vs-first-cycle-PCR split *inside* the floor | M3 | the sequencing/pre-amplification split now has a standard — the deep-MIG consensus residual, which is what `--pre-amp-error auto` fits (`docs/quality_floor.rst`). What is still unsplit is what MADE the floor, and that needs two chemistries to compare rather than a better estimator: the same template through an RT protocol and through a DNA one. Data, not code |
-| 2 | The rest of the published comparisons | M5 | **MIGEC v1, MAGERI, UMIErrorCorrect, UMI-tools and fgbio are done and scored** (`docs/postprocessing.rst`, `docs/validation.rst`, `docs/grouping.rst`). Open: Cell Ranger, and UMI-VarCal which is running. This is what the version number is waiting on, not the code |
+| 2 | The rest of the published comparisons | M5 | **MIGEC v1, MAGERI, UMIErrorCorrect, UMI-tools, fgbio and Cell Ranger are done and scored** (`docs/postprocessing.rst`, `docs/validation.rst`, `docs/grouping.rst`, `docs/single_cell.rst`). Open: UMI-VarCal, which cannot run on the certified arms (single-end). This is what the version number is waiting on, not the code |
 | 3 | The last two rows of the ctDNA table | M5 | the ground truth is **found and scored**: `PRJNA788522` / `PRJNA507366`, certified VAF, real 12 nt inline UMI. Done: LoFreq and Mutect2 on the identical consensus BAM, a MAPQ 20 floor, adapter trimming, and UMIErrorCorrect end to end (`assets/ctdna_callers.tsv`). Running: the **no-consensus baseline** -- same reads, same aligner, same callers, reads instead of molecules -- and **UMI-VarCal** |
 | 4 | Bit-parallel matcher | M2 | last, deliberately: the scan is O(offsets x pattern) and is **not** the bottleneck. It goes in when a benchmark says so |
 
@@ -376,8 +376,30 @@ model has to use the evidence that survives at one read:
       UMI the two are indistinguishable, and at **1.5 reads per UMI they separate 28x** with the
       consensus quality matched to 5e-4 -- 142 calls of which 137 are false against 5 of 5 clean.
       `assets/mageri.tsv`, `assets/mageri_variants.tsv`
-- [ ] `2026-migec-benchmark` repo and `isalgo/umi_data`. Cell Ranger is the one comparator still
-      unrun, and its only overlap is cell calling, which is OrdMag plus a knee by design
+- [ ] `2026-migec-benchmark` repo and `isalgo/umi_data`. Every comparator is now run.
+- [x] **Cell Ranger 5.0.0 head to head** (2026-08-14), `scripts/compare_cellranger.py`, on
+      `sc5p_v2_hs_PBMC_1k` VDJ-T, both lanes. migec calls **888 cells against 479**, sharing 470,
+      and loses **1.9 points of reads-in-cells** (84.88% against 86.80%) -- the 418 extra barcodes
+      are nearly empty, so a cell count alone is not an accuracy figure. Barcode validity 88.90%
+      against 90.60%. Never: Cell Ranger is not re-run (Linux x86_64, licence-gated), so the
+      comparator is 10x's own published 5.0.0 output AND a `cellranger vdj` **10.1.0 run here**
+      (`scripts/cellranger_vdj.sbatch`, 16 cores on aldan3, 8m44s / 936 MB). The two versions agree
+      at **Jaccard 0.9938**, which is the control saying the migec gap is not version drift. Cost:
+      **35.0 s / 679 MB against 524.5 s / 936 MB** for the stages that answer these axes, ~90 s end
+      to end with `assemble --contig` + arda. Never: the two cell sets are different populations, so
+      five counts and never a ratio. It also found the `checkout` UMI-counter bug and proved
+      5.0.0's published `Median TRB UMIs per Cell` wrong -- see `CLAUDE.md`.
+      `assets/cellranger.tsv`, `docs/single_cell.rst`
+- [x] **The per-cell chain axis** (2026-08-14), `scripts/compare_cellranger_chains.py`. migec
+      assembles per MOLECULE, arda annotates (`--cell-from migec`), the cell's chain is a vote:
+      **TRA 426/426 and TRB 468/469 recall** against 5.0.0, and 424/424 + 468/469 against 10.1.0,
+      junction agreement 0.95 / 0.99, in 22 s over 47,584 consensuses with no per-cell assembler.
+      Never: **depth does not buy junction coverage on a co-terminal chemistry** -- a molecule is a
+      pile at one position, mean consensus 204 nt against the ~508 nt amplicon, 16.5% carry a
+      junction where a per-read-uniform model predicts 0.975. `assets/cellranger_chains.tsv`
+- [x] **`--contig` is 19.7x faster, byte-identical** (2026-08-14): `place_reads` asks union-find
+      before it runs the seed scan, because `join` already returns when the roots match. 640.9 s ->
+      32.6 s on 47,584 molecules, consensus FASTQ and `mig.tsv` MD5-identical
 - [x] ctDNA ground truth **located, not simulated** (2026-08-13): `PRJNA788522` (72 runs, cfDNA
       reference material at 0 / 0.125 / 0.25 / 1% VAF x 5/20/80 ng x 3.3/10/30x, three replicates)
       and `PRJNA507366` (28 runs, six polymerases plus 0.031% / 0.0625% VAF). Both carry a real

--- a/SOURCES.md
+++ b/SOURCES.md
@@ -135,7 +135,9 @@ rates fitted as Beta, counts as Beta-Binomial, `Q = −10 log10 P`, capped at 10
 | Why this one | the **VDJ-T** library, not GEX: 569 MB against tens of GB, and it is the part that matters here. The 3' GEX libraries carry the same barcode structure at 100x the size |
 | Layout | 5' v2: **R1 = 16 nt cell barcode + 10 nt UMI, exactly 26 nt and nothing else**; R2 = 90 nt cDNA; I1/I2 index reads present |
 | Pattern | `^XXXXXXXXXXXXXXXXNNNNNNNNNN`, or `--preset 10x-v2`, or the slice `cell:0:16,16:26`. Purely positional — there is no constant sequence to anchor on, which is why the pattern grammar had to allow a scored-nothing pattern at a fixed offset |
-| Measured | 3,155,166 reads, **100% assigned**, 221,024 barcodes at 14.28 reads each, effective UMI length 9.97/10. refine on **R2** (the mate carrying the cDNA): 305,702 molecules, **813 cells** called by OrdMag, clonality 0.0014 |
+| Lanes | **Two**, `L001` 3,155,166 read pairs and `L002` 3,146,407, summing to **6,301,573** — exactly what Cell Ranger reports for this library. `checkout` takes one R1 and one R2, so both lanes are concatenated first (a concatenated gzip stream is valid), **in the same order for both mates**: `assemble` matches mates by position and refuses only on a length mismatch, so a swapped lane order mis-mates every pair silently |
+| Measured, one lane (`L001`, 2026-08-13) | 3,155,166 reads, **100% assigned**, effective UMI length 9.97/10. refine on **R2**: 305,702 molecules, 813 cells by OrdMag, clonality 0.0014. Never: the "221,024 barcodes at 14.28 reads each" published here previously was **distinct UMIs pooled over all cells**, not molecules — `checkout` keyed its counters on the UMI alone until 2026-08-14. The true L001 figures are **311,962 molecules `(cell, UMI)` over 101,634 cell barcodes, 10.11 reads each** |
+| Measured, both lanes (2026-08-14) | 6,301,573 reads. refine on **R2** with `--cell-whitelist`: 467,810 molecules, **888 cells** by OrdMag, 84.88% of reads in called cells, 88.90% of reads on the whitelist. Cell Ranger 5.0.0 on the identical input: 479 cells, 86.80%, 90.60%. `assets/cellranger.tsv` |
 | Note: | refine and assemble take **R2**, not R1: trimming the pattern leaves R1 empty, so the payload evidence is vacuous there and the reported clonality comes out 1.0 saying so |
 | Provenance | experimental (10x public) |
 | Regenerate the fixture | `migec checkout R1 R2 --preset 10x-v2 --sample PBMC -o co/` then `migec subsample co/PBMC_R2.fq.gz -o sc5p_v2_hs_PBMC_1k_t_cells1pct.fq.gz --keep 1` |
@@ -395,6 +397,60 @@ and `fastq-dump` exits 3.
 | What | consensuses, exactness, wall clock and peak RSS for MIGEC 1.2.9 and migec 2 at matched MIG-size thresholds |
 | Regenerate | `python scripts/compare_migec_v1.py --out DIR --jar migec-1.2.9.jar --molecules 20000 --clones 200 --coverage 8 --min-count {1,5} --tsv out.tsv` |
 | Provenance | derived (computed) |
+
+### `assets/cellranger.tsv`
+
+| Item | Value |
+|---|---|
+| What | barcode validity, cell set and reads-in-cells for Cell Ranger 5.0.0 and migec on `sc5p_v2_hs_PBMC_1k` VDJ-T, one row per (tool, whitelist) |
+| Regenerate | `python scripts/compare_cellranger.py --r1 R1.fq.gz --r2 R2.fq.gz --cellranger-dir DIR --whitelist 737K-august-2016.txt --out DIR --threads 8 --tsv assets/cellranger.tsv` (both lanes concatenated first; ~48 s at 8 threads) |
+| Never | **two Cell Ranger versions, and the version is a COLUMN.** 10x's published calls are 5.0.0; `cellranger vdj` 10.1.0 was run here (`scripts/cellranger_vdj.sbatch`, 16 cores, under `/projects/immunestatus` on aldan3 — never `/projects/cdr3*`). They agree at **Jaccard 0.9938** (477 cells shared of 479 / 478), which is the control saying the migec gap is not version drift |
+| Never | **the cost row is not like for like unless you read the third stage.** Cell Ranger's 524.5 s / 936 MB also assembles and annotates a contig per cell; migec's 35.0 s / 679 MB is `checkout` + `refine`, which is what answers these three axes. End to end with `assemble --contig` + arda it is ~90 s, still 5.8x. Different hardware (16-core node against 8 laptop threads), so the ratio is the number and not the seconds |
+| Never | **5.0.0's published `Median TRB UMIs per Cell` of 12.0 matches neither denominator in its own tables** (both give 11.0). 10.1.0 reports TRA 4.0 / TRB 11.0, exactly the medians over ALL cells in its own tables; 5.0.0's TRA 5.0 is the median over cells that HAVE that chain. Derive these from the contig tables and name the denominator |
+| Fetch | `cellranger-10.1.0.tar.gz` from a 10x signed URL (expires; re-request from the download page) and `refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0.tar.gz` (3,370,702 bytes, unsigned). Note: the V(D)J reference is germline only, ~3 MB, not a genome |
+| Never | **the cell sets are not the same population**, so the table carries five counts (`cells_called`, `cells_shared`, `cells_tool_only`, `cells_other_only` per side) and never a ratio. migec's gate is molecules of any sequence; Cell Ranger's is "assembled a productive V(D)J contig", so a B cell is correctly in one set and not the other |
+| Never | **no molecule-count column for Cell Ranger.** Its `umis` counts UMIs incorporated into a filtered contig (7,623 over 479 cells); migec counts every molecule of any sequence. Different populations, not an over-count |
+| Never | **`frac_reads_in_cells` is READS.** Every column of `<sample>.cells.tsv` and `<sample>.cell_rank.tsv` is molecules, and the molecule fraction reads 57% where the read fraction reads 85% — ambient barcodes are molecule-rich and read-poor. It is summed from `<sample>.barcodes.tsv` |
+| Never | **Cell Ranger's AIRR count columns are the inverse of arda's.** In `_airr_rearrangement.tsv`, `consensus_count` is reads and `duplicate_count` is UMIs — verified on all 943 rows. The script asserts the identity against the contig CSV and refuses if it moves |
+| Provenance | experimental (10x's published Cell Ranger 5.0.0 calls); the migec columns and every comparison derived |
+
+### `assets/cellranger_chains.tsv`
+
+| Item | Value |
+|---|---|
+| What | per-(cell, locus) chain recall and junction agreement for migec plus arda against Cell Ranger's assembled contigs, one row per locus |
+| Regenerate | `migec assemble ref/PBMC.fq.gz -o asm/ --contig --min-reads 30`, then `python scripts/compare_cellranger_chains.py --consensus asm/PBMC.consensus.fq.gz --cellranger-dir DIR --min-reads 30 --out DIR --arda $(which arda) --tsv assets/cellranger_chains.tsv` |
+| Never | **recall is primary, concordance is secondary.** Concordance is scored over the chains BOTH tools called, a self-selecting denominator that reads high whatever happens. A missed chain is the unrecoverable error |
+| Never | **arda runs `rnaseq --exact`, not the amplicon preset.** `amplicon` turns on `two_pass`, `fast_segments` and `segment_only_v`, which assume a primer-anchored read spanning V into J; these are 90 nt tiles of a fragmented amplicon, the documented loss case, and the preset would confound the comparison with a preset choice |
+| Never | **the migec-only chains are not scored.** Cell Ranger's set is the reference, not the truth, and a second productive TRA is allelic inclusion rather than an error |
+| Note | measured 2026-08-14 against **both** Cell Ranger versions, which is why `cellranger_version` is a column: against 5.0.0, TRA 426/426 at 0.9507 and TRB 468/469 at 0.9915; against 10.1.0, TRA 424/424 at 0.9505 and TRB 468/469 at 0.9915. 7,855 of 47,584 molecules carried a cell, a locus and a junction |
+| Never | **depth does not buy junction coverage here.** Reads of one (cell, UMI) are co-terminal in 92% of 10x groups, so a molecule is a pile at one position and not a tiling: at `--min-reads 30` the mean consensus is 204 nt against the ~508 nt amplicon, and only 16.5% of molecules carry a junction. A per-read-uniform model predicts 0.975 and is wrong |
+| Provenance | experimental (10x's published Cell Ranger 5.0.0 calls); the migec and arda columns derived |
+
+### `assets/cellranger_contigs.tsv`
+
+| Item | Value |
+|---|---|
+| What | reference-free per-cell contig assembly scored against Cell Ranger's own assembled contigs: k-mer coverage, exact CDR3 containment, contig N50, chain recall and doublet candidates, one row per ablation |
+| Regenerate | `migec assemble ref/PBMC.fq.gz -o asm_all/ --contig --min-reads 1`, then `python scripts/compare_cellranger_contigs.py --consensus asm_all/PBMC.consensus.fq.gz --cellranger-dir DIR --out DIR --arda ~/vcs/code/arda/.venv/bin/arda --tsv assets/cellranger_contigs.tsv` (~110 s: three arda runs plus the scoring) |
+| Never | **`--min-reads 1`, and that is not sloppiness.** A one-read molecule is a poor consensus and one more WINDOW of the transcript, and the assembly needs the second thing. A depth cut throws the tiling away; it belongs to the per-molecule route (`assets/cellranger_chains.tsv`), not to this one |
+| Never | **the first row is a ceiling, not a method.** It is the share of each Cell Ranger contig's 25-mers present in its own cell's raw molecules before any assembly runs — 0.9990, with 942 of 943 CDR3 nucleotide sequences appearing verbatim. It is the premise being measured, and every other row is scored against it |
+| Never | **contig N50 is a description, never a score.** The no-adapter-trim row has the HIGHEST N50 in the table (580 against 536) and the lowest value in every other column: a contig built across an adapter is a longer contig and a wronger one |
+| Never | **the ablation rows are the evidence for the defaults**, not decoration. CDR3 exact: 0.9894 with everything on, 0.9820 without the haplotype phasing, 0.9618 without the adapter trim. Depth weighting is the third ingredient, has no flag, and is measured in `arda.singlecell`'s module table at 0.967 against 0.988 |
+| Note | measured 2026-08-15 on `sc5p_v2_hs_PBMC_1k` VDJ-T, both lanes, 479 Cell Ranger cells and 249,635 migec molecules: 933/943 CDR3s recovered verbatim (TRA 454/464, **TRB 479/479**), chain recall 0.9777, N50 536 nt, 17 doublet candidates, 23 s |
+| Note | the assembly reads **no germline reference**; arda annotates the finished contigs. Cell Ranger is not re-run — the comparator is its published 5.0.0 output |
+| Provenance | experimental (10x's published Cell Ranger 5.0.0 contigs and annotations); the migec and arda columns derived |
+
+### 10x barcode whitelist — `737K-august-2016.txt`
+
+| Item | Value |
+|---|---|
+| What | the 737,280-entry cell-barcode whitelist for 3' v2 and 5' v1/v2 chemistries; `refine --cell-whitelist` takes it |
+| Fetch | `curl -L -o 737K-august-2016.txt https://github.com/10XGenomics/supernova/raw/master/tenkit/lib/python/tenkit/barcodes/737K-august-2016.txt` |
+| Verify | 12,533,760 bytes, 737,280 lines. All 479 `sc5p_v2_hs_PBMC_1k` Cell Ranger cell barcodes are on it |
+| Note | 10x ship it inside the Cell Ranger tarball and it is **not** in `10XGenomics/cellranger` on GitHub; `10XGenomics/supernova` is 10x's own mirror of the same file. Licensed under 10x's terms, so it is fetched rather than vendored |
+| Note | barcodes are **forward** — no reverse complement. Measured: all 479 appear verbatim as 16 nt R1 prefixes and 0 of their reverse complements do |
+| Provenance | vendor (10x) |
 
 ### `assets/mageri.tsv`
 

--- a/assets/cellranger.tsv
+++ b/assets/cellranger.tsv
@@ -1,0 +1,4 @@
+tool	whitelist	expect_cells	reads_total	frac_valid_barcode	cells_called	cells_shared	cells_tool_only	cells_other_only	molecules	frac_reads_in_cells	wall_seconds	peak_rss_bytes
+cellranger-10.1.0	737K-august-2016		6301573	0.9060	478					0.8640	524.5	958263296
+migec	none	3000	6301573	0.8827	890	469	421	9	496373	0.8426	14.1	675741696
+migec	737K-august-2016	3000	6301573	0.8890	888	469	419	9	467810	0.8488	35.0	679149568

--- a/assets/cellranger_chains.tsv
+++ b/assets/cellranger_chains.tsv
@@ -1,0 +1,5 @@
+cellranger_version	locus	min_reads	min_molecules	cells_scored	chains_cellranger	chains_migec	chains_shared	chain_recall	junction_aa_concordance	molecules_scored	molecules_total
+5.0.0	TRA	30	1	479	426	451	426	1.0000	0.9507	7855	47584
+5.0.0	TRB	30	1	479	469	474	468	0.9979	0.9915	7855	47584
+10.1.0	TRA	30	1	478	424	450	424	1.0000	0.9505	7855	47584
+10.1.0	TRB	30	1	478	469	473	468	0.9979	0.9915	7855	47584

--- a/assets/cellranger_contigs.tsv
+++ b/assets/cellranger_contigs.tsv
@@ -1,0 +1,5 @@
+method	variant	cells	contigs_scored	kmer_coverage_mean	contigs_at_90pct	cdr3_exact	cdr3_total	cdr3_exact_rate	contig_n50	chain_recall	doublet_candidates	wall_note
+migec molecules (no assembly)	ceiling	479	943	0.9990	943	942	943	0.9989	0	nan	0	k-mer ceiling, not a method
+arda cells	default	479	943	0.9759	892	933	943	0.9894	536	0.9777	17	10944 contigs from 249635 molecules
+arda cells	no phasing	479	943	0.9663	868	926	943	0.9820	460	0.9714	12	9898 contigs from 249635 molecules
+arda cells	no adapter trim	479	943	0.9525	879	907	943	0.9618	580	0.9491	16	10998 contigs from 249635 molecules

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -138,7 +138,13 @@ Consensus FASTQ
 
 The pipeline output, and the contract with everything downstream::
 
-    @<sample>.<mig>[.<g>]:<CB>:<UMI> RX:Z:<umi>\tQX:Z:<umi qual>\tCB:Z:<cell>\t...
+    @<sample>[.<cell>].<umi>[.c<k>][.<m>] RX:Z:<umi>\tBC:Z:<sample>\tCB:Z:<cell>\tMI:Z:<name>\tcD:i:<reads>
+
+Every field is separated by a **dot**, and there is no colon anywhere in the name. ``.c<k>`` is the
+overlap component in ``--contig`` mode and ``.<m>`` the linkage split index; each is written only
+when there is more than one, so the name carries three, four or five fields. A parser must
+therefore read it **from the right** rather than indexing from the left -- and a sample id may
+itself contain a dot, since ``validate_sample_id`` does not forbid one.
 
 Tags are separated by **TAB**, not space: ``bwa mem -C`` and ``minimap2 -y`` append the FASTQ
 comment verbatim into the SAM record, so it has to be SAM-conformant or the resulting BAM is

--- a/docs/postprocessing.rst
+++ b/docs/postprocessing.rst
@@ -127,6 +127,9 @@ Read next
        by an artifact -- and which of the three you are in
    * - :doc:`Grouping accuracy <grouping>`
      - map-first against collapse-first, scored against a known truth
+   * - :doc:`Single cell <single_cell>`
+     - migec against Cell Ranger on a 10x droplet library: barcode validity, cell calling, and
+       what a cell count does and does not tell you
 
 .. toctree::
    :maxdepth: 1
@@ -135,3 +138,4 @@ Read next
    downstream
    variants
    detection
+   single_cell

--- a/docs/refine.rst
+++ b/docs/refine.rst
@@ -229,6 +229,41 @@ The **knee** — the rank furthest from the chord joining the ends of the log-lo
 When they disagree by more than a factor of three the report says so, because one of them is
 describing a library the other is not.
 
+That distance **is** Kneedle's (`Satopaa 2011 <https://raghavan.usc.edu/papers/kneedle-simplex11.pdf>`_)
+normalised ``|y_n - (1 - x_n)|`` up to a constant, taken at its **global maximum**.
+
+.. warning::
+
+   **Kneedle's published selection rule is degenerate without the smoothing spline the paper
+   specifies.** It walks the *local* maxima and stops at the first that then falls by a
+   sensitivity step. Measured on ``sc5p_v2_hs_PBMC_1k``'s 136,032 barcodes:
+
+   =========================================  =======  ===========
+   rule                                       rank     molecules
+   =========================================  =======  ===========
+   Kneedle, unsmoothed (287 local maxima)     15       1,057
+   Kneedle, smoothed over 0.01 log-rank       358      314
+   Kneedle, smoothed over 0.10 log-rank       180      435
+   **global maximum (what migec computes)**   **376**  **308**
+   =========================================  =======  ===========
+
+   The unsmoothed answer would call fifteen cells. Properly smoothed it lands on the global
+   maximum to within 5%, and over-smoothing drifts it off again — so the global maximum reaches
+   the same place with no smoothing parameter to tune.
+
+.. warning::
+
+   **A global maximum always exists, so the knee is guarded.** An ambient-only library returns a
+   rank too, and reporting it beside OrdMag would read as two methods disagreeing about where the
+   cells are rather than as a curve with no cells in it. The knee is refused below **ten times the
+   mean molecules per observed barcode** — one order of magnitude, the unit a log-log curve is
+   read in — and the report then says the curve has no knee.
+
+   The mean alone was tried and is too weak: an ambient-only library of 1-3 molecules per barcode
+   is a step curve whose corner sits at 3 against a mean of 2.0 and clears a mean-only test at
+   1.5x. On the real library the knee is 308 against a mean of 3.38, a factor of 91. The two cases
+   are two orders apart, so the boundary is not a tuned one.
+
 **Never: EmptyDrops-style rescue of low-count cells is deliberately not reproduced.** It is Cell
 Ranger's job, and imitating it would make every comparison against their calls unreachable by
 construction rather than by measurement. The benchmark gate is written against recall of their

--- a/docs/single_cell.rst
+++ b/docs/single_cell.rst
@@ -1,0 +1,356 @@
+Cell Ranger: cell barcodes, cell calling, and what the cell count costs
+=======================================================================
+
+migec and `Cell Ranger <https://www.10xgenomics.com/support/software/cell-ranger/latest>`_ both
+read a 10x droplet library front to back: given R1 = 16 nt cell barcode + 10 nt UMI, which reads
+carry a real GEM barcode, which barcodes are cells, and how much of the library is in them. Those
+three questions are comparable and are compared here, on ``sc5p_v2_hs_PBMC_1k`` VDJ-T.
+
+.. code-block:: bash
+
+   cat sc5p_v2_hs_PBMC_1k_t_S1_L00{1,2}_R1_001.fastq.gz > R1.fq.gz
+   cat sc5p_v2_hs_PBMC_1k_t_S1_L00{1,2}_R2_001.fastq.gz > R2.fq.gz
+   python scripts/compare_cellranger.py --r1 R1.fq.gz --r2 R2.fq.gz \
+       --cellranger-dir cellranger_published/ --whitelist 737K-august-2016.txt \
+       --out /tmp/cr --threads 8 --tsv assets/cellranger.tsv
+
+Cell Ranger is run **both ways**. 10x publish their own Cell Ranger 5.0.0 output for this exact
+library, and ``cellranger vdj`` 10.1.0 was run here on the same reads
+(``scripts/cellranger_vdj.sbatch``, 16 cores) so the comparison has a cost axis and a second
+version to bound drift against.
+
+.. list-table:: Cell Ranger against itself, five major versions apart
+   :header-rows: 1
+   :widths: 22 13 13 13 13 26
+
+   * - version
+     - cells
+     - contigs
+     - shared
+     - Jaccard
+     - source
+   * - 5.0.0
+     - 479
+     - 943
+     - 477
+     - 0.9938
+     - published by 10x
+   * - 10.1.0
+     - 478
+     - 939
+     - 477
+     - 0.9938
+     - run here, 524.5 s / 936 MB
+
+**Version drift is negligible**, so the migec-against-Cell-Ranger gap below is not a version
+artefact. That control is why 10.1.0 was run at all.
+
+.. note::
+
+   **5.0.0's published ``Median TRB UMIs per Cell`` of 12.0 is not reproducible from its own
+   deposited tables**, under either denominator -- both give 11.0. 10.1.0 reports 11.0 for TRB and
+   4.0 for TRA, and both are exactly the median over **all** cells in its own tables; 5.0.0's TRA
+   figure of 5.0 is the median over **cells that have that chain**. So 10.1.0 changed the
+   denominator and is self-consistent, while 5.0.0's TRB value matches neither. Derive these from
+   the contig tables and say which denominator you used; do not quote ``metrics_summary`` for them.
+
+The result
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 13 13 13 13 13 13
+
+   * - tool
+     - reads
+     - valid barcode
+     - cells
+     - shared
+     - molecules
+     - reads in cells
+   * - Cell Ranger 10.1.0
+     - 6,301,573
+     - **90.60%**
+     - 478
+     - 469
+     -
+     - **86.40%**
+   * - migec, no whitelist
+     - 6,301,573
+     - 88.27%
+     - 890
+     - 469
+     - 496,373
+     - 84.26%
+   * - migec, 737K whitelist
+     - 6,301,573
+     - 88.90%
+     - 888
+     - 469
+     - 467,810
+     - 84.88%
+
+What it costs
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 22 22 22
+
+   * - stage
+     - wall clock
+     - peak RSS
+     - what it produces
+   * - ``cellranger vdj`` 10.1.0, 16 cores
+     - 524.5 s
+     - 936 MB
+     - cell calls **and** per-cell contigs, annotated
+   * - migec ``checkout`` + ``refine``, 8 threads
+     - **35.0 s**
+     - **679 MB**
+     - cell calls
+   * - \+ ``assemble --contig`` + arda
+     - ~90 s total
+     - 679 MB
+     - \+ per-molecule consensus, annotated
+
+Never: **35 s against 524 s is not like for like, and the table says so.** Cell Ranger's single
+invocation also assembles and annotates a contig per cell; the stages that answer the three axes
+above are 35 s of migec. The comparable end-to-end number is the third row -- **~90 s against
+524.5 s, still 5.8x** -- and it produces per-*molecule* resolution that Cell Ranger's output does
+not have. Both numbers are on the same 6,301,573 read pairs, but on different hardware: Cell Ranger
+on a 16-core cluster node, migec on 8 threads of a laptop, so read the ratio and not the seconds.
+
+**migec calls 1.86x the cells and loses 1.5 points of reads-in-cells.** That is the whole finding,
+and it says the extra barcodes are nearly empty: 419 barcodes beyond Cell Ranger's set hold about
+one and a half percent of the library between them. A cell count is not an accuracy figure on its
+own.
+
+The two cell sets are **not nested and do not measure the same thing**. migec's gate is molecules of
+any sequence; Cell Ranger's is "assembled a productive V(D)J contig". A B cell or a monocyte with
+plenty of molecules is correctly a migec cell and correctly not a Cell Ranger VDJ cell. So the table
+carries five counts -- 478, 888, 469 shared, 419 migec-only, 9 Cell-Ranger-only -- and never a
+ratio. The 9 Cell Ranger cells migec misses sit below the OrdMag threshold on raw molecule counts.
+
+Note: **the whitelist is worth 0.63 points of validity and two cells.** Snapping off-list barcodes
+onto the list lifts read validity from 88.27% to 88.90% against Cell Ranger's 90.60%, and moves the
+cell count by two. The remaining 1.7-point gap is reads whose R1 is not a barcode at all: the
+deepest off-list 26-mers are phase shifts of one fixed sequence (``GGTCCGTCTTGCGCCG`` and its
+rotations), which ``refine``'s pass 0 remaps rather than drops.
+
+Per-cell receptor chains, without a per-cell assembler
+------------------------------------------------------
+
+Cell Ranger assembles a contig per **cell** from every read of a barcode, then annotates it. migec
+assembles a consensus per **molecule**, annotates each one with
+`arda <https://github.com/antigenomics/arda>`_, and lets the cell's chain be a vote over its
+molecules. Same question -- which chain is in which cell -- reached with and without an assembler.
+
+.. code-block:: bash
+
+   migec assemble ref/PBMC.fq.gz -o asm/ --contig --min-reads 30
+   python scripts/compare_cellranger_chains.py --consensus asm/PBMC.consensus.fq.gz \
+       --cellranger-dir cellranger_published/ --min-reads 30 --out /tmp/chains \
+       --tsv assets/cellranger_chains.tsv
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 20 16 14 19 19
+
+   * - locus
+     - Cell Ranger chains
+     - migec chains
+     - shared
+     - chain recall
+     - junction agreement
+   * - TRA, against 5.0.0
+     - 426
+     - 451
+     - 426
+     - **1.0000**
+     - 0.9507
+   * - TRB, against 5.0.0
+     - 469
+     - 474
+     - 468
+     - **0.9979**
+     - **0.9915**
+   * - TRA, against 10.1.0
+     - 424
+     - 450
+     - 424
+     - **1.0000**
+     - 0.9505
+   * - TRB, against 10.1.0
+     - 469
+     - 473
+     - 468
+     - **0.9979**
+     - **0.9915**
+
+**Every TRA chain and all but one TRB chain Cell Ranger found is also found by migec plus arda**,
+in 22 seconds over 47,584 consensuses, with no per-cell assembly step anywhere -- and the result is
+the same against both Cell Ranger versions, which is the point of scoring it twice. Recall is the
+metric that leads because a missed chain is the unrecoverable error; junction agreement is
+secondary and is scored only over the chains both tools called, which is a self-selecting
+denominator.
+
+migec calls slightly *more* chains than Cell Ranger on both loci (451 against 426, 474 against
+469). Those extra calls are not scored here -- Cell Ranger's set is the reference, not the truth,
+and a second productive TRA is allelic inclusion rather than an error.
+
+.. warning::
+
+   **Depth does not buy junction coverage on this chemistry, and the obvious arithmetic says it
+   does.** The tempting model places each read uniformly over the ~508 nt amplicon: a 90 nt read
+   then spans the median 42 nt junction with probability 0.114, and 30 reads give
+   :math:`1 - 0.886^{30} = 0.975`. Measured, that is wrong. Reads of one ``(CB, UMI)`` are
+   co-terminal in 92% of 10x groups (:doc:`fragmented`), so a molecule is a **pile at one
+   position**, not a tiling, and its consensus covers one window however deep it is. At
+   ``--min-reads 30`` the mean consensus is **204 nt, not 508**, and **7,855 of 47,584 molecules
+   (16.5%)** carry a cell, a locus and a junction -- close to the single-window 0.32 the geometry
+   predicts, nowhere near 0.975. The depth cut is still right, because a deep pile gives a clean
+   consensus; it just does not extend one.
+
+Per-cell contigs, reference-free
+--------------------------------
+
+The window a molecule covers is one window, but *different molecules start at different
+positions*, so a cell's molecules tile its transcript. That is measurable before any assembler
+exists, and it is the ceiling everything below is scored against: **99.90% of the 25-mers of Cell
+Ranger's 943 filtered contigs are already present in their own cell's raw migec molecules**, and
+942 of 943 CDR3 nucleotide sequences appear verbatim in one of them. The contig is in the data.
+
+``arda cells`` assembles it -- adapter trim, 25-mer seeds, verified overlaps, union-find layout,
+haplotype phasing, weighted column consensus -- with **no germline reference until the finished
+contigs are annotated**.
+
+.. code-block:: bash
+
+   migec assemble ref/PBMC.fq.gz -o asm_all/ --contig --min-reads 1
+   python scripts/compare_cellranger_contigs.py --consensus asm_all/PBMC.consensus.fq.gz \
+       --cellranger-dir cellranger_published/ --out /tmp/contigs \
+       --tsv assets/cellranger_contigs.tsv
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 13 13 16 10 12 12
+
+   * - variant
+     - k-mer coverage
+     - contigs at >=90%
+     - CDR3 exact
+     - N50
+     - chain recall
+     - doublets
+   * - molecules, no assembly
+     - 0.9990
+     - 943
+     - 942 (0.9989)
+     - --
+     - --
+     - --
+   * - ``arda cells``, default
+     - **0.9759**
+     - **892**
+     - **933 (0.9894)**
+     - 536
+     - **0.9777**
+     - 17
+   * - no phasing
+     - 0.9663
+     - 868
+     - 926 (0.9820)
+     - 460
+     - 0.9714
+     - 12
+   * - no adapter trim
+     - 0.9525
+     - 879
+     - 907 (0.9618)
+     - 580
+     - 0.9491
+     - 16
+
+Per chain at the default: **TRA 454/464 (0.9784), TRB 479/479 (1.0000)**. 479 cells and 249,635
+molecules in 23 s.
+
+.. warning::
+
+   **``--min-reads`` throws away the tiling.** A one-read molecule is a poor consensus and one
+   more window of the transcript, and the second thing is what the assembly needs. This axis runs
+   at ``--min-reads 1`` on purpose; the depth cut belongs to the per-molecule route above, not to
+   this one.
+
+.. warning::
+
+   **Contig N50 is a description, never a score.** The no-adapter-trim row has the highest N50 in
+   the table, 580 against 536, and the lowest value in every other column. A contig built across
+   an adapter is a longer contig and a wronger one.
+
+Doublets: two chains of the same locus
+--------------------------------------
+
+One TRA and one TRB in a droplet is a paired T cell. Two TRB is a doublet -- and until the
+phasing landed it was invisible **by construction**: the two chains share their constant region,
+so the overlap layout puts them in one component and the column consensus averages their
+junctions into a sequence that is neither. On a synthetic cell built from two TRB receptors that
+produced one 918 nt contig with no callable junction; with the phasing on, both true junctions
+come back. On this library it moves chain recall 0.9714 to 0.9777 and doublet candidates 12 to 17.
+
+What separates a real second chain from ambient RNA is **productivity first and count second**:
+of the extra chains Cell Ranger agrees with, 60/60 are productive; of those it does not, 20/128
+are. An extra chain carried by exactly one molecule is contamination 96-97% of the time. The
+sweep that fixes the thresholds, the per-cell table and the QC panels are documented in arda's
+`single-cell page <https://arda.readthedocs.io/en/latest/singlecell.html>`_.
+
+.. _not-comparable:
+
+Measured, and not comparable
+----------------------------
+
+Each of these was computed and then deliberately kept out of the table, because the number would
+have been read as a comparison and is not one.
+
+* **Molecules per cell.** Cell Ranger's ``umis`` counts UMIs incorporated into a *filtered contig* --
+  7,623 over 479 cells, median 15 -- while migec counts every molecule of any sequence, a median of
+  178 on the same barcodes. That is a different population, not a 12x over-count, so no ratio of the
+  two appears.
+* **migec's "100% assigned" against "Valid Barcodes 90.6%".** Not the same measurement. On
+  ``^XXXXXXXXXXXXXXXXNNNNNNNNNN`` there is nothing to score, so the assigned rate is 100% by
+  construction. The comparable quantity is the read share on the whitelist, which is what the table
+  reports.
+* **Cell Ranger's per-contig ``reads`` as a reads-in-cells figure.** Summing it gives 63.61%, which
+  is not any published metric -- it excludes reads in cells that went into no contig. The 86.80%
+  comes from ``metrics_summary.csv`` and is not recoverable from the per-contig tables.
+* **``Median TRB UMIs per Cell``.** Not cut but corrected -- see the note at the top of the page.
+  5.0.0's published 12.0 matches neither denominator in its own tables; 10.1.0 reports 11.0 and is
+  self-consistent.
+
+Two traps worth naming
+----------------------
+
+.. warning::
+
+   **Both lanes, or neither.** ``L001`` is 3,155,166 read pairs and ``L002`` is 3,146,407; only
+   their sum, 6,301,573, is what Cell Ranger reports. ``checkout`` takes one R1 and one R2, so the
+   lanes are concatenated first -- and **in the same order for both mates**. ``assemble`` matches
+   mates by position and refuses only on a length mismatch, so ``L001+L002`` against ``L002+L001``
+   has the right length and mis-mates every pair with nothing flagging it. The script asserts the
+   read total before scoring anything.
+
+.. warning::
+
+   **Cell Ranger's AIRR export means the opposite of arda's by the same column name.** In
+   ``_airr_rearrangement.tsv``, ``consensus_count`` is READS and ``duplicate_count`` is UMIs --
+   verified on all 943 rows against the contig CSV, and the inverse of what arda writes. A join on
+   the column names silently swaps reads for molecules, which on this library is a factor of 526.
+   The script reads counts only from ``_filtered_contig_annotations.csv`` and asserts the identity
+   at runtime rather than trusting it.
+
+Read next
+---------
+
+* :doc:`refine` -- OrdMag cell calling, the knee, and ``--cell-whitelist``.
+* :doc:`umi_statistics` -- the barcode-space arithmetic behind the validity figures.
+* :doc:`downstream` -- what composes with migec's output and what replaces a stage of it.

--- a/docs/umi_statistics.rst
+++ b/docs/umi_statistics.rst
@@ -85,9 +85,16 @@ Two numbers follow, and both are reported per sample:
    \qquad
    E[\text{collisions}] \approx \frac{M^2}{2}\prod_j m_j
 
-``effective_length`` is what your UMI is *worth* in bases. A 12 nt UMI whose first eight positions
-are fixed has an effective length of 4 and a usable space of 256 — and will collide constantly. The
-nominal length tells you nothing on its own.
+``effective_length`` is what your barcode is *worth* in bases. A 12 nt UMI whose first eight
+positions are fixed has an effective length of 4 and a usable space of 256 — and will collide
+constantly. The nominal length tells you nothing on its own.
+
+.. note::
+
+   It is measured over the **whole barcode**, cell then UMI, because that is what the counters are
+   keyed on: a molecule is sample + cell + UMI. So on a single-cell run compare it against
+   ``barcode_length`` (26 nt for 10x), never against ``umi_length`` (10 nt) — all three lengths are
+   columns of ``checkout.summary.tsv`` for exactly that reason. On a bulk library they coincide.
 
 .. note::
 

--- a/include/migec/checkout.hpp
+++ b/include/migec/checkout.hpp
@@ -341,6 +341,11 @@ struct CheckoutStats {
     std::vector<std::array<uint64_t, 61>> sample_phred;    // parallel to sample_ids
     std::vector<std::array<uint64_t, kPayloadHistLen>> sample_payload_len;  // and so is this
     std::vector<UmiCounts> umi_counts;   // parallel to sample_ids
+    // Also parallel to sample_ids. The counters are keyed on the WHOLE barcode -- cell then UMI --
+    // because a molecule is sample + cell + UMI and a UMI-keyed counter merges every cell's copy of
+    // one UMI. So the composition's length is the barcode's, and this is what splits it back into
+    // the two reported lengths. Zero on a bulk library, where the two coincide.
+    std::vector<int> sample_cell_length;
     double wall_seconds = 0.0;
     double reads_per_second = 0.0;
     size_t peak_rss_bytes = 0;

--- a/include/migec/version.hpp
+++ b/include/migec/version.hpp
@@ -4,6 +4,6 @@
 // Kept in sync by hand with pyproject.toml and python/migec/__init__.py. The release checklist in
 // CLAUDE.md lists all three; CI prints them so a mismatch is visible before a release, and
 // publish.yml asserts the pyproject version equals the release tag.
-#define MIGEC_VERSION "2.4.0"
+#define MIGEC_VERSION "2.5.0"
 
 #endif  // MIGEC_VERSION_HPP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "migec"
-version = "2.4.0"  # keep in sync with include/migec/version.hpp and python/migec/__init__.py
+version = "2.5.0"  # keep in sync with include/migec/version.hpp and python/migec/__init__.py
 description = "UMI barcode extraction, correction and consensus assembly for barcoded sequencing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/migec/__init__.py
+++ b/python/migec/__init__.py
@@ -5,7 +5,7 @@ fallback, because a fallback would make a failed C++ build look like a successfu
 surface forty minutes into a run.
 """
 
-__version__ = "2.4.0"  # keep in sync with pyproject.toml and include/migec/version.hpp
+__version__ = "2.5.0"  # keep in sync with pyproject.toml and include/migec/version.hpp
 
 from migec import _core
 from migec._core import (

--- a/python/migec/checkout.py
+++ b/python/migec/checkout.py
@@ -121,7 +121,11 @@ def _write_tables(out: Path, summary: dict) -> None:
     with open(out / "checkout.summary.tsv", "w") as fh:
         fh.write(
             "sample_id\treads\tumis\tmean_reads_per_umi\treads_in_migs_ge5\tover_sequenced\t"
-            "umi_length\teffective_length\teffective_space\ttotal_entropy\ttotal_information\t"
+            # `cell_length` and `barcode_length` sit beside `umi_length` because every column
+            # after them -- effective length, space, entropy -- is measured over the whole
+            # barcode, and on a single-cell run that is not the UMI.
+            "umi_length\tcell_length\tbarcode_length\t"
+            "effective_length\teffective_space\ttotal_entropy\ttotal_information\t"
             "umi_error_rate\tumis_merged\treads_merged\tmolecules_observed\tmolecules_corrected\t"
             "saturated\n"
         )
@@ -129,6 +133,7 @@ def _write_tables(out: Path, summary: dict) -> None:
             fh.write(
                 f"{s['sample_id']}\t{s['reads']}\t{s['umis']}\t{s['mean_reads_per_umi']:.4f}\t"
                 f"{s['reads_in_migs_ge5']:.6f}\t{int(s['over_sequenced'])}\t{s['umi_length']}\t"
+                f"{s['cell_length']}\t{s['barcode_length']}\t"
                 f"{s['effective_length']:.4f}\t{s['effective_space']:.1f}\t"
                 f"{s['total_entropy']:.4f}\t{s['total_information']:.4f}\t"
                 f"{s['umi_error_rate']:.3e}\t{s['umis_merged']}\t{s['reads_merged']}\t"
@@ -148,7 +153,10 @@ def _write_tables(out: Path, summary: dict) -> None:
     # above, but they are the numbers that say whether a molecule count means anything.
     with open(out / "checkout.barcode_space.tsv", "w") as fh:
         fh.write(
-            "sample_id\tumi_length\tnominal_space\teffective_space\teffective_length\tbias_loss\t"
+            # `barcode_length`, not `umi_length`: the value is the counter's own length, which is
+            # cell + UMI, and the whole birthday arithmetic below is over that space.
+            "sample_id\tbarcode_length\tnominal_space\teffective_space\teffective_length\t"
+            "bias_loss\t"
             "observed_barcodes\toccupancy\tlambda\tmolecules\thidden\tp_multi\tsaturated\t"
             "err_from_phred\tmean_phred\terr_from_polymerase\terr_predicted\terr_estimated\t"
             "err_ratio\tbarcodes_with_error\tneighbour_occupancy\terr_unreliable\n"
@@ -281,14 +289,17 @@ def format_report(summary: dict) -> str:
     )
     lines.append("")
     lines.append(
-        f"{'sample':<12}{'reads':>12}{'UMIs':>12}{'reads/UMI':>11}{'UMI len':>9}{'eff len':>9}"
-        f"{'payload':>9}"
+        f"{'sample':<12}{'reads':>12}{'UMIs':>12}{'reads/UMI':>11}{'UMI len':>9}{'bc len':>8}"
+        f"{'eff len':>9}{'payload':>9}"
     )
     for s in summary["samples"]:
+        # `eff len` is measured over the barcode, so the barcode's length is printed beside it.
+        # On a bulk library the two length columns are equal; on a single-cell one they are 10
+        # and 26, and reading the effective 25.4 against the 10 says the UMI is impossibly good.
         lines.append(
             f"{s['sample_id']:<12}{s['reads']:>12,}{s['umis']:>12,}"
-            f"{s['mean_reads_per_umi']:>11.2f}{s['umi_length']:>9}{s['effective_length']:>9.2f}"
-            f"{s['mean_payload_length']:>9.1f}"
+            f"{s['mean_reads_per_umi']:>11.2f}{s['umi_length']:>9}{s['barcode_length']:>8}"
+            f"{s['effective_length']:>9.2f}{s['mean_payload_length']:>9.1f}"
         )
 
     # The birthday arithmetic, per sample. Occupancy is the number that decides whether the
@@ -411,9 +422,13 @@ def format_report(summary: dict) -> str:
             f"molecules are seen once"
         )
     for s in summary["samples"]:
-        if s["umi_length"] and s["effective_length"] < 0.8 * s["umi_length"]:
+        # Never: compare a rate to a rate, and a length to the length it was measured over.
+        # `effective_length` is a property of the COUNTER, which is keyed on cell + UMI, so it
+        # must be weighed against the barcode. Against the UMI alone a 10x library reads 25.4 nt
+        # usable of a 10 nt UMI and the warning is silently dead on every single-cell run.
+        if s["barcode_length"] and s["effective_length"] < 0.8 * s["barcode_length"]:
             warnings.append(
-                f"{s['sample_id']}: UMI is {s['umi_length']} nt but only "
+                f"{s['sample_id']}: barcode is {s['barcode_length']} nt but only "
                 f"{s['effective_length']:.1f} nt of it is usable -- the base composition is skewed, "
                 f"so collisions are more frequent than the length suggests"
             )

--- a/python/migec/refine.py
+++ b/python/migec/refine.py
@@ -119,8 +119,13 @@ def format_report(summary: dict) -> str:
             f"at >= {s['cell_threshold']:,} molecules (OrdMag)",
             f"            {s['molecules_in_called']:,} molecules in called cells "
             f"({_pct(s['molecules_in_called'], max(s['molecules'], 1))} of all)",
-            f"            the curve breaks at rank {s['knee_rank']:,} "
-            f"({s['knee_molecules']:,} molecules) -- the knee, for comparison",
+            (
+                f"            the curve breaks at rank {s['knee_rank']:,} "
+                f"({s['knee_molecules']:,} molecules) -- the knee, for comparison"
+                if s["knee_rank"]
+                else "            the curve has no knee above the mean molecules per barcode -- "
+                     "nothing to compare the threshold against"
+            ),
             "",
         ]
     lines += [

--- a/scripts/cellranger_vdj.sbatch
+++ b/scripts/cellranger_vdj.sbatch
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH --job-name=cellranger-vdj
+#SBATCH --partition=medium
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --time=8:00:00
+#SBATCH --output=%x-%j.out
+# 2026-08-14
+#
+# `cellranger vdj` on sc5p_v2_hs_PBMC_1k VDJ-T, so the migec comparison has a Cell Ranger side that
+# was actually RUN rather than only read off 10x's published tables. Two things come out of it that
+# the published output cannot give:
+#   1. wall clock and peak RSS, which is the cost axis every other compare_* script reports;
+#   2. a SECOND Cell Ranger version. The published calls are 5.0.0; this is 10.1.0, so the gap
+#      between them bounds how much of any migec-vs-Cell-Ranger difference is just version drift.
+#
+# Never: `/projects/cdr3*` is read-only for us. This lives in /projects/immunestatus, which had
+# 4.6T free at 52% used -- checked before anything was downloaded.
+#
+# Never: compute never runs on an aldan3 frontend. The download was I/O and ran there deliberately;
+# this is 16 cores for hours and belongs in SLURM.
+#
+# Submit:
+#   aldan3 push scripts/cellranger_vdj.sbatch /projects/immunestatus/migec-cellranger/
+#   aldan3 slurm submit /projects/immunestatus/migec-cellranger/cellranger_vdj.sbatch
+set -euo pipefail
+
+D=/projects/immunestatus/migec-cellranger
+CR="$D/cellranger-10.1.0/cellranger"
+REF="$D/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0"
+FASTQS="$D/sc5p_v2_hs_PBMC_1k_t_fastqs"
+RUN="$D/run"
+
+mkdir -p "$RUN" && cd "$RUN"
+# Cell Ranger refuses to overwrite an existing run id, and a half-finished one is worse than none.
+rm -rf PBMC_vdj
+
+echo "=== cellranger $($CR --version) on $(hostname), $SLURM_CPUS_PER_TASK cores ==="
+echo "=== started $(date) ==="
+
+/usr/bin/time -v "$CR" vdj \
+    --id=PBMC_vdj \
+    --reference="$REF" \
+    --fastqs="$FASTQS" \
+    --sample=sc5p_v2_hs_PBMC_1k_t \
+    --localcores="$SLURM_CPUS_PER_TASK" \
+    --localmem=60 \
+    --disable-ui
+
+echo "=== done $(date) ==="
+echo "=== metrics ==="
+cat PBMC_vdj/outs/metrics_summary.csv
+echo "=== cells ==="
+tail -n +2 PBMC_vdj/outs/filtered_contig_annotations.csv | cut -d, -f1 | sort -u | wc -l

--- a/scripts/compare_cellranger.py
+++ b/scripts/compare_cellranger.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+# 2026-08-14
+#
+# migec against Cell Ranger 5.0.0 on a 10x droplet library, `sc5p_v2_hs_PBMC_1k` VDJ-T.
+#
+# The overlap between the two is the droplet front end: given R1 = 16 nt cell barcode + 10 nt UMI,
+# which reads carry a real GEM barcode, which barcodes are cells, and what share of the library is
+# in them. Three axes, all of which both tools answer for the whole library rather than for a
+# receptor. Cell Ranger's own published output for this exact library is the comparator.
+#
+# Note: the two tools do NOT answer the same question about a cell. migec's gate is molecules of
+# any sequence; Cell Ranger's is "assembled a productive V(D)J contig", so a B cell or a monocyte
+# is correctly a migec cell and correctly not a Cell Ranger one. The cell sets are therefore
+# reported as five counts and never as a ratio -- a bare 479-against-N reads as an accuracy claim
+# and is a population statement. The number that says whether the difference costs anything is
+# reads in called cells, which is on the same denominator for both.
+#
+# Never: `Cell Ranger's AIRR export means the opposite of arda's by the same column name.` In
+# `_airr_rearrangement.tsv`, `consensus_count` is READS and `duplicate_count` is UMIs -- verified
+# on all 943 rows against the contig CSV, and the inverse of what arda writes
+# (`arda/src/arda/rnaseq/correct.py:1332`). This script therefore reads counts only from
+# `_filtered_contig_annotations.csv`, whose `reads` and `umis` are unambiguous, and asserts the
+# identity at runtime rather than trusting it.
+#
+# Never: `the molecule counts are not comparable and are not published as if they were.` Cell
+# Ranger's `umis` counts UMIs incorporated into a filtered contig -- 7,623 over 479 cells -- while
+# migec counts every molecule of any sequence, a median of 178 per cell on the same barcodes.
+# That is a different population, not an over-count, so no ratio of the two appears here.
+#
+# Note: `the cost row comes from a run, not from a table.` `metrics_summary.csv` carries no runtime
+# or memory, so the Cell Ranger figures are read off `/usr/bin/time -v` in
+# `scripts/cellranger_vdj.sbatch` -- Cell Ranger is Linux x86_64, so it runs on the cluster and
+# migec's own row is measured on the same input. Pass them with `--cellranger-seconds` and
+# `--cellranger-rss-bytes`; omit them and the columns are blank rather than guessed.
+#
+# Usage:
+#     python scripts/compare_cellranger.py \
+#         --r1 /tmp/cr/in/R1.fq.gz --r2 /tmp/cr/in/R2.fq.gz \
+#         --cellranger-dir ~/data/10x/sc5p_v2_hs_PBMC_1k_t_cellranger \
+#         --whitelist ~/data/10x/737K-august-2016.txt \
+#         --out /tmp/cr/run --threads 8 --tsv assets/cellranger.tsv
+#
+# Get the Cell Ranger side (no binary needed -- these are 10x's own published outputs):
+#     B=https://cf.10xgenomics.com/samples/cell-vdj/5.0.0/sc5p_v2_hs_PBMC_1k/sc5p_v2_hs_PBMC_1k_t
+#     for f in filtered_contig_annotations.csv airr_rearrangement.tsv metrics_summary.csv; do
+#         curl -sO ${B}_${f}; done
+# Get the whitelist (10x ship it inside the cellranger tarball; this is their own mirror of it):
+#     curl -L -o 737K-august-2016.txt \
+#       https://github.com/10XGenomics/supernova/raw/master/tenkit/lib/python/tenkit/barcodes/737K-august-2016.txt
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Cell Ranger reports this library as 6,301,573 read pairs, which is BOTH lanes. L001 alone is
+# 3,155,166 and is what every earlier migec measurement of this library saw.
+CELLRANGER_READ_PAIRS = 6_301_573
+CELLRANGER_CELLS = 479
+CELLRANGER_CONTIGS = 943
+
+
+def read_whitelist(path: Path) -> set[str]:
+    """The 10x barcode list, one per line. Everything from the first `-` is dropped, as
+    `migec`'s own loader does (src/whitelist.cpp:22-24) -- 10x write a `-1` gem-group suffix."""
+    wl = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        wl.add(line.split("-", 1)[0])
+    if not wl:
+        raise SystemExit(f"{path} holds no barcodes")
+    lengths = {len(b) for b in wl}
+    if len(lengths) != 1:
+        raise SystemExit(f"{path} mixes barcode lengths {sorted(lengths)} -- it is not a whitelist")
+    return wl
+
+
+def read_cellranger_cells(contig_csv: Path) -> tuple[set[str], int]:
+    """The Cell Ranger cell set, and the contig count.
+
+    Never: filter on `is_cell`. `_all_contig_annotations.csv` spans 699 barcodes of which only 479
+    are cells, and nothing else in the file says you took the wrong ones.
+    """
+    cells, contigs = set(), 0
+    with open(contig_csv, newline="") as fh:
+        for row in csv.DictReader(fh):
+            if row["is_cell"].strip().lower() != "true":
+                continue
+            contigs += 1
+            cells.add(row["barcode"].split("-", 1)[0])
+    return cells, contigs
+
+
+def check_airr_counts(airr_tsv: Path, contig_csv: Path) -> None:
+    """Read back what Cell Ranger's AIRR count columns actually mean, and refuse if they moved.
+
+    `consensus_count` must equal the contig CSV's `reads` and `duplicate_count` its `umis`. arda
+    spells these two the other way round, so a join on the column names silently swaps reads for
+    molecules -- a factor of 526 on this library.
+    """
+    reads, umis = {}, {}
+    with open(contig_csv, newline="") as fh:
+        for row in csv.DictReader(fh):
+            reads[row["contig_id"]] = int(row["reads"])
+            umis[row["contig_id"]] = int(row["umis"])
+    with open(airr_tsv, newline="") as fh:
+        for row in csv.DictReader(fh, delimiter="\t"):
+            cid = row["sequence_id"]
+            if cid not in reads:
+                continue
+            cc, dc = int(float(row["consensus_count"])), int(float(row["duplicate_count"]))
+            if cc != reads[cid] or dc != umis[cid]:
+                raise SystemExit(
+                    f"Cell Ranger AIRR row {cid}: consensus_count {cc} / duplicate_count {dc} "
+                    f"against reads {reads[cid]} / umis {umis[cid]} in the contig CSV. The count "
+                    f"columns have moved; arda spells these two the other way round, so nothing "
+                    f"downstream of here can be trusted to be counting the same thing"
+                )
+
+
+def read_metrics(path: Path) -> dict[str, str]:
+    """`metrics_summary.csv` is two lines, header and values, with quoted thousands separators."""
+    with open(path, newline="") as fh:
+        rows = list(csv.reader(fh))
+    return dict(zip(rows[0], rows[1]))
+
+
+def _pct(value: str) -> float:
+    return float(value.strip().rstrip("%")) / 100.0
+
+
+def per_cell_reads(barcodes_tsv: Path) -> tuple[dict[str, int], int, int]:
+    """Reads per cell, total reads and total molecules, from refine's own barcode table.
+
+    Never: this cannot come from `<sample>.cells.tsv` or `<sample>.cell_rank.tsv` -- every column
+    in both is MOLECULES. Ambient barcodes are molecule-rich and read-poor, so the molecule
+    fraction reads 57% where the read fraction, which is what Cell Ranger's 86.8% means, reads 84%.
+    `<sample>.barcodes.tsv` is one row per (cell, umi) and carries `reads`.
+    """
+    reads: dict[str, int] = {}
+    total_reads = molecules = 0
+    with open(barcodes_tsv, newline="") as fh:
+        for row in csv.DictReader(fh, delimiter="\t"):
+            n = int(row["reads"])
+            reads[row["cell"]] = reads.get(row["cell"], 0) + n
+            total_reads += n
+            molecules += 1
+    return reads, total_reads, molecules
+
+
+def called_cells(cells_tsv: Path) -> set[str]:
+    with open(cells_tsv, newline="") as fh:
+        return {r["cell"] for r in csv.DictReader(fh, delimiter="\t") if r["called"] == "1"}
+
+
+def run_checkout(r1: Path, r2: Path, out: Path, threads: int) -> tuple[dict, Path]:
+    """Demultiplex once. The whitelist is a `refine` knob, so checkout does not depend on it and
+    is not re-run per whitelist setting -- that was half the wall clock of this comparison."""
+    from migec.checkout import run as checkout_run
+    from migec.sheet import preset
+
+    out.mkdir(parents=True, exist_ok=True)
+    sheet = out / "barcodes.txt"
+    sheet.write_text(f"PBMC\t{preset('10x-v2')[0]}\n")
+
+    co = out / "co"
+    c = checkout_run(r1, sheet, co, r2, threads=threads)
+    if c["total"] != CELLRANGER_READ_PAIRS:
+        raise SystemExit(
+            f"checkout read {c['total']:,} read pairs, not the {CELLRANGER_READ_PAIRS:,} Cell "
+            f"Ranger reports. L001 alone is 3,155,166 -- concatenate BOTH lanes, in the same order "
+            f"for R1 and R2, or the comparison is of two different libraries"
+        )
+
+    # Never: select the payload mate BY NAME. Paired checkout always writes `PBMC_R1.fq.gz` too,
+    # holding one zero-length record per pair -- the min_payload gate is charged against the pair,
+    # so a 26-of-26 trim on R1 is not a rejection. A glob picks up both, and refine on the empty
+    # mate succeeds, reports clonality 1.0 and corrects on counts alone.
+    mates = sorted(co.glob("PBMC_R2.fq.gz"))
+    if len(mates) != 1:
+        raise SystemExit(f"{len(mates)} files match {co}/PBMC_R2.fq.gz -- expected exactly one "
+                         f"payload mate; refine on the barcode mate would report vacuous evidence")
+    return c, mates[0]
+
+
+def run_refine(mate: Path, out: Path, whitelist: Path | str, expect_cells: int,
+               threads: int) -> dict:
+    """Correct and call cells, once per whitelist setting."""
+    from migec.refine import run as refine_run
+
+    r = refine_run(mate, out, cell_whitelist=whitelist, expect_cells=expect_cells,
+                   threads=threads)
+    reads, total_reads, molecules = per_cell_reads(out / "PBMC.barcodes.tsv")
+    return {
+        "refine": r,
+        "reads_per_cell": reads,
+        "reads_total": total_reads,
+        "molecules": molecules,
+        "cells": called_cells(out / "PBMC.cells.tsv"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--r1", type=Path, required=True, help="R1, BOTH lanes concatenated")
+    ap.add_argument("--r2", type=Path, required=True, help="R2, the same lanes in the same order")
+    ap.add_argument("--cellranger-dir", type=Path, required=True,
+                    help="directory holding 10x's published Cell Ranger outputs")
+    ap.add_argument("--whitelist", type=Path, required=True, help="737K-august-2016.txt")
+    ap.add_argument("--expect-cells", type=int, default=3000, help="OrdMag prior")
+    ap.add_argument("--cellranger-version", default="5.0.0",
+                    help="labels the Cell Ranger row; the published calls are 5.0.0")
+    # The guard below exists to catch a wrong directory, not to pin a version -- so the expected
+    # counts are settable, and having to set them is what makes pointing at another version
+    # deliberate. 5.0.0 published 479 cells over 943 contigs; 10.1.0 run here gives 478 over 939.
+    ap.add_argument("--expect-cellranger-cells", type=int, default=CELLRANGER_CELLS)
+    ap.add_argument("--expect-cellranger-contigs", type=int, default=CELLRANGER_CONTIGS)
+    ap.add_argument("--cellranger-seconds", type=float, default=None,
+                    help="wall clock of a `cellranger vdj` run, from /usr/bin/time -v")
+    ap.add_argument("--cellranger-rss-bytes", type=int, default=None,
+                    help="peak RSS of that run, from /usr/bin/time -v (which reports kbytes)")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--threads", type=int, default=0)
+    ap.add_argument("--tsv", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    d = args.cellranger_dir.expanduser()
+    contig_csv = next(iter(sorted(list(d.glob("*filtered_contig_annotations.csv")))), None)
+    airr_tsv = next(iter(sorted(list(d.glob("*airr_rearrangement.tsv")))), None)
+    metrics_csv = next(iter(sorted(list(d.glob("*metrics_summary.csv")))), None)
+    for name, p in (("filtered_contig_annotations.csv", contig_csv),
+                    ("airr_rearrangement.tsv", airr_tsv),
+                    ("metrics_summary.csv", metrics_csv)):
+        if p is None:
+            raise SystemExit(f"no *_{name} in {d} -- see the header for the fetch command")
+
+    check_airr_counts(airr_tsv, contig_csv)
+    cr_cells, cr_contigs = read_cellranger_cells(contig_csv)
+    if (len(cr_cells) != args.expect_cellranger_cells
+            or cr_contigs != args.expect_cellranger_contigs):
+        raise SystemExit(
+            f"{len(cr_cells)} barcodes with is_cell true over {cr_contigs} contigs, not the "
+            f"{args.expect_cellranger_cells} / {args.expect_cellranger_contigs} expected. Either "
+            f"this is a different sample, or it is a different Cell Ranger version -- 5.0.0 "
+            f"published 479/943 and 10.1.0 gives 478/939 on the same reads. Pass "
+            f"--expect-cellranger-cells / --expect-cellranger-contigs to say which you meant"
+        )
+    metrics = read_metrics(metrics_csv)
+    wl = read_whitelist(args.whitelist.expanduser())
+    missing = sum(1 for b in cr_cells if b not in wl)
+    if missing:
+        raise SystemExit(f"{missing} of {len(cr_cells)} Cell Ranger cell barcodes are not on "
+                         f"{args.whitelist} -- that is the wrong whitelist for this chemistry")
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    rows = []
+
+    # Cell Ranger's row. Only the three quantities it publishes on the whole library; its molecule
+    # count is per contig and is deliberately absent (see the Never: in the header).
+    rows.append({
+        "tool": f"cellranger-{args.cellranger_version}",
+        "whitelist": "737K-august-2016",
+        "expect_cells": "",
+        "reads_total": CELLRANGER_READ_PAIRS,
+        "frac_valid_barcode": _pct(metrics["Valid Barcodes"]),
+        "cells_called": len(cr_cells),
+        "cells_shared": "",
+        "cells_tool_only": "",
+        "cells_other_only": "",
+        "molecules": "",
+        "frac_reads_in_cells": _pct(metrics["Fraction Reads in Cells"]),
+        "wall_seconds": args.cellranger_seconds if args.cellranger_seconds is not None else "",
+        "peak_rss_bytes": args.cellranger_rss_bytes if args.cellranger_rss_bytes is not None else "",
+    })
+
+    # Demultiplex ONCE -- the whitelist is a refine knob. Its clock is charged to BOTH migec rows,
+    # because Cell Ranger's single number covers demultiplexing too.
+    t0 = time.perf_counter()
+    _, mate = run_checkout(args.r1, args.r2, args.out, args.threads)
+    checkout_seconds = time.perf_counter() - t0
+
+    # Then refine twice: without the whitelist so the raw barcodes are visible and the
+    # read-weighted validity can be measured against the list, and with it so the cell set is the
+    # corrected one.
+    for label, whitelist in (("off", ""), ("on", str(args.whitelist.expanduser()))):
+        t1 = time.perf_counter()
+        m = run_refine(mate, args.out / f"wl_{label}", whitelist, args.expect_cells, args.threads)
+        refine_seconds = time.perf_counter() - t1
+        # Read-weighted, because Cell Ranger's 90.6% is a share of READS. refine's own whitelist
+        # tally counts DISTINCT BARCODES (include/migec/whitelist.hpp:47-53) -- only
+        # `reads_corrected` is read-weighted -- so the read weighting here is this script's.
+        valid = sum(n for cell, n in m["reads_per_cell"].items() if cell in wl)
+        shared = m["cells"] & cr_cells
+        in_cells = sum(m["reads_per_cell"].get(c, 0) for c in m["cells"])
+        rows.append({
+            "tool": "migec",
+            "whitelist": "737K-august-2016" if whitelist else "none",
+            "expect_cells": args.expect_cells,
+            "reads_total": m["reads_total"],
+            "frac_valid_barcode": valid / max(m["reads_total"], 1),
+            "cells_called": len(m["cells"]),
+            "cells_shared": len(shared),
+            "cells_tool_only": len(m["cells"] - cr_cells),
+            "cells_other_only": len(cr_cells - m["cells"]),
+            "molecules": m["molecules"],
+            "frac_reads_in_cells": in_cells / max(m["reads_total"], 1),
+            "wall_seconds": checkout_seconds + refine_seconds,
+            "peak_rss_bytes": m["refine"].get("peak_rss_bytes", ""),
+        })
+        w = m["refine"]["whitelist"]
+        print(f"# migec whitelist {label}: {w['exact']:,} barcodes exact, {w['corrected']:,} "
+              f"snapped, {w['off_list']:,} off-list, background prior "
+              f"{w['background_prior']:.2e}", file=sys.stderr)
+
+    cols = ["tool", "whitelist", "expect_cells", "reads_total", "frac_valid_barcode",
+            "cells_called", "cells_shared", "cells_tool_only", "cells_other_only",
+            "molecules", "frac_reads_in_cells", "wall_seconds", "peak_rss_bytes"]
+    fmt = {"frac_valid_barcode": ".4f", "frac_reads_in_cells": ".4f", "wall_seconds": ".1f"}
+    lines = ["\t".join(cols)]
+    for row in rows:
+        lines.append("\t".join(
+            "" if row[c] == "" else format(row[c], fmt.get(c, ".0f")) if isinstance(row[c], float)
+            else str(row[c])
+            for c in cols
+        ))
+    out = "\n".join(lines)
+    print(out)
+    if args.tsv:
+        args.tsv.write_text(out + "\n")
+
+    mig = [r for r in rows if r["tool"] == "migec"]
+    if mig:
+        best = mig[-1]
+        print(f"# migec calls {best['cells_called']:,} cells against Cell Ranger's "
+              f"{CELLRANGER_CELLS}, sharing {best['cells_shared']:,}; reads in cells "
+              f"{best['frac_reads_in_cells']:.1%} against {_pct(metrics['Fraction Reads in Cells']):.1%}",
+              file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compare_cellranger_chains.py
+++ b/scripts/compare_cellranger_chains.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# 2026-08-14
+#
+# The per-cell chain axis of the Cell Ranger comparison: given the same droplet library, do migec
+# plus arda put the same receptor chain in the same cell as Cell Ranger's assembler?
+#
+# The two pipelines get there differently and that is the point. Cell Ranger assembles a per-CELL
+# contig from every read of a barcode, then annotates it. migec assembles a per-MOLECULE consensus
+# (`assemble --contig`, one component per overlap group), annotates each molecule with arda, and
+# lets the cell's chain call be a vote over its molecules. So this scores the same question --
+# which chain is in which cell -- reached with and without a per-cell assembler.
+#
+# Never: `restrict to molecules deep enough to carry a junction, and report the denominator.`
+# `molecules_scored` and `molecules_total` are columns so it is never implicit.
+#
+# Note: **depth does not buy coverage here, and the arithmetic that says it does is wrong.** The
+# tempting model is that each read is placed uniformly over the ~508 nt amplicon, so a 90 nt read
+# spans the median 42 nt junction with p = 0.114 and 30 reads give 1 - 0.886^30 = 0.975. Measured,
+# that is false: reads of one (CB, UMI) are co-terminal in this chemistry (X1: 92% of groups), so a
+# molecule is a PILE at one position, not a tiling of the amplicon, and its consensus covers one
+# window however deep it is. At `--min-reads 30` the mean consensus is 204 nt, not 508, and
+# **7,855 of 47,584 molecules (16.5%) carry a cell, a locus and a junction** -- close to the
+# single-window 0.32 the geometry predicts and nowhere near 0.975. The depth cut is still right,
+# because a deep pile gives a clean consensus; it just does not extend it.
+#
+# Never: `recall is the primary metric, not concordance.` Concordance is computed over the chains
+# BOTH tools called, which is a self-selecting denominator that reads high whatever happens. A
+# missed chain is the unrecoverable error, so `chain_recall = chains_shared / chains_cellranger`
+# leads and concordance follows it.
+#
+# Never: `arda runs with --exact, not the amplicon preset.` `amplicon` turns on `two_pass`,
+# `fast_segments` and `segment_only_v`, which assume a primer-anchored read spanning V into J.
+# These are 90 nt tiles of a fragmented amplicon -- the documented loss case -- so the preset would
+# confound the comparison with a preset choice. `arda rnaseq --exact` is the zero preset.
+#
+# Never: `Cell Ranger's AIRR count columns are the inverse of arda's.` `consensus_count` is READS
+# and `duplicate_count` is UMIs there; arda spells them the other way round. Nothing here joins on
+# those names -- the chain identity is (cell, locus, junction_aa).
+#
+# Usage:
+#     python scripts/compare_cellranger_chains.py \
+#         --consensus /tmp/cr/asm30/PBMC.fq.gz \
+#         --cellranger-dir ~/data/10x/sc5p_v2_hs_PBMC_1k_t_cellranger \
+#         --out /tmp/cr/chains --min-reads 30 --tsv assets/cellranger_chains.tsv
+#
+# The consensus comes from:
+#     migec assemble <refined.fq.gz> -o asm/ --contig --min-reads 30
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from compare_cellranger import read_cellranger_cells  # noqa: E402
+
+
+def cellranger_chains(contig_csv: Path) -> dict[tuple[str, str], set[str]]:
+    """(cell, locus) -> the set of CDR3 amino-acid strings Cell Ranger called there.
+
+    `is_cell` filtered, and the `-1` gem-group suffix stripped so the key matches migec's bare
+    16 nt barcode. A contig with no CDR3 call contributes the cell but no sequence, which is why
+    the value is a set and not a string.
+    """
+    out: dict[tuple[str, str], set[str]] = defaultdict(set)
+    with open(contig_csv, newline="") as fh:
+        for row in csv.DictReader(fh):
+            if row["is_cell"].strip().lower() != "true":
+                continue
+            cdr3 = (row.get("cdr3") or "").strip()
+            if cdr3 and cdr3 != "None":
+                out[(row["barcode"].split("-", 1)[0], row["chain"])].add(cdr3)
+    return dict(out)
+
+
+def run_arda(consensus: Path, out_dir: Path, arda: str, threads: int) -> Path:
+    """`arda rnaseq --exact --cell-from migec`, returning the per-read AIRR TSV."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    argv = [arda, "rnaseq", "--exact", "--cell-from", "migec",
+            "--r1", str(consensus), "--out-dir", str(out_dir), "--out-prefix", "cells",
+            "--threads", str(threads)]
+    p = subprocess.run(argv, capture_output=True, text=True)
+    if p.returncode:
+        raise SystemExit(f"arda failed ({p.returncode}):\n{p.stderr[-2000:]}")
+    airr = out_dir / "cells.airr.tsv"
+    if not airr.exists():
+        raise SystemExit(f"arda wrote no {airr}; it reported:\n{p.stderr[-2000:]}")
+    return airr
+
+
+def migec_chains(airr: Path, min_molecules: int) -> tuple[dict, dict]:
+    """(cell, locus) -> the junction_aa a vote over that cell's molecules picks, and the votes.
+
+    A cell's chain call is the modal junction over its molecules. Never the first molecule: the
+    consensus file is written in barcode order, so "first" is a property of the barcode.
+    """
+    votes: dict[tuple[str, str], dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    with open(airr, newline="") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        if "cell_id" not in (reader.fieldnames or []):
+            raise SystemExit(
+                f"{airr} has no `cell_id` column -- arda ran without `--cell-from`, so every "
+                f"molecule is cellless and every recall below would be 0.0 with nothing saying why"
+            )
+        for row in reader:
+            cell, locus = row.get("cell_id", ""), row.get("locus", "")
+            junction = (row.get("junction_aa") or "").strip()
+            if not cell or not locus or not junction:
+                continue
+            votes[(cell, locus)][junction] += 1
+    called = {k: max(v.items(), key=lambda kv: (kv[1], kv[0]))[0]
+              for k, v in votes.items() if sum(v.values()) >= min_molecules}
+    return called, {k: sum(v.values()) for k, v in votes.items()}
+
+
+def count_consensus(path: Path) -> int:
+    opener = gzip.open if str(path).endswith(".gz") else open
+    with opener(path, "rt") as fh:
+        return sum(1 for i, _ in enumerate(fh) if i % 4 == 0)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--consensus", type=Path, required=True,
+                    help="migec assemble --contig output, already depth-restricted")
+    ap.add_argument("--cellranger-dir", type=Path, required=True)
+    ap.add_argument("--arda", default=shutil.which("arda") or "arda")
+    ap.add_argument("--cellranger-version", default="5.0.0",
+                    help="labels the rows; two runs of this script concatenate into one table, so "
+                         "the version has to be a COLUMN and not something you remember")
+    ap.add_argument("--min-reads", type=int, required=True,
+                    help="the depth cut already applied to --consensus; reported, not applied")
+    ap.add_argument("--min-molecules", type=int, default=1,
+                    help="molecules a (cell, locus) needs before its chain is called")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--threads", type=int, default=8)
+    ap.add_argument("--tsv", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    d = args.cellranger_dir.expanduser()
+    contig_csv = next(iter(sorted(list(d.glob("*filtered_contig_annotations.csv")))), None)
+    if contig_csv is None:
+        raise SystemExit(f"no *_filtered_contig_annotations.csv in {d}")
+    cr_cells, _ = read_cellranger_cells(contig_csv)
+    cr = cellranger_chains(contig_csv)
+
+    if not args.consensus.exists():
+        raise SystemExit(f"{args.consensus} does not exist -- run `migec assemble --contig "
+                         f"--min-reads {args.min_reads}` first")
+    molecules_total = count_consensus(args.consensus)
+
+    airr = run_arda(args.consensus, args.out, args.arda, args.threads)
+    mig, mig_votes = migec_chains(airr, args.min_molecules)
+    molecules_scored = sum(mig_votes.values())
+
+    # Score only where BOTH tools could have called: Cell Ranger's cells. A migec cell Cell Ranger
+    # never called is not a miss by either tool, it is the population difference the other table
+    # already reports.
+    loci = sorted({locus for (_, locus) in cr})
+    rows = []
+    for locus in loci:
+        cr_here = {c: j for (c, ln), j in cr.items() if ln == locus and c in cr_cells}
+        mig_here = {c: j for (c, ln), j in mig.items() if ln == locus and c in cr_cells}
+        shared = set(cr_here) & set(mig_here)
+        agree = sum(1 for c in shared if mig_here[c] in cr_here[c])
+        rows.append({
+            "cellranger_version": args.cellranger_version,
+            "locus": locus,
+            "min_reads": args.min_reads,
+            "min_molecules": args.min_molecules,
+            "cells_scored": len(cr_cells),
+            "chains_cellranger": len(cr_here),
+            "chains_migec": len(mig_here),
+            "chains_shared": len(shared),
+            "chain_recall": len(shared) / max(len(cr_here), 1),
+            "junction_aa_concordance": agree / max(len(shared), 1),
+            "molecules_scored": molecules_scored,
+            "molecules_total": molecules_total,
+        })
+
+    cols = ["cellranger_version", "locus", "min_reads", "min_molecules", "cells_scored", "chains_cellranger",
+            "chains_migec", "chains_shared", "chain_recall", "junction_aa_concordance",
+            "molecules_scored", "molecules_total"]
+    fmt = {"chain_recall": ".4f", "junction_aa_concordance": ".4f"}
+    lines = ["\t".join(cols)]
+    for row in rows:
+        lines.append("\t".join(
+            format(row[c], fmt.get(c, ".0f")) if isinstance(row[c], float) else str(row[c])
+            for c in cols))
+    out = "\n".join(lines)
+    print(out)
+    if args.tsv:
+        args.tsv.write_text(out + "\n")
+
+    print(f"# {molecules_total:,} consensuses at >= {args.min_reads} reads; "
+          f"{molecules_scored:,} carried a cell, a locus and a junction", file=sys.stderr)
+    for row in rows:
+        print(f"# {row['locus']}: recall {row['chain_recall']:.1%} "
+              f"({row['chains_shared']}/{row['chains_cellranger']}), "
+              f"junction agreement {row['junction_aa_concordance']:.1%}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compare_cellranger_contigs.py
+++ b/scripts/compare_cellranger_contigs.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# 2026-08-15
+#
+# The contig axis of the Cell Ranger comparison: with no germline reference in the assembly at
+# all, does migec plus arda reconstruct the same per-cell V(D)J contigs Cell Ranger's assembler
+# does?
+#
+# The two get there differently. Cell Ranger assembles a per-CELL contig from every read of a
+# barcode and annotates it against a germline reference. migec collapses each MOLECULE to a
+# consensus, and `arda cells` overlap-assembles a cell's molecules into contigs -- k-mer seeds,
+# verified overlaps, union-find layout, weighted column consensus. No reference is read until the
+# contigs are annotated, which is after the assembly is finished.
+#
+# Never: `the premise is measured before the method is`. Reads of one (CB, UMI) are co-terminal in
+# this chemistry, so a molecule's consensus is a pile at one position and covers one window of the
+# transcript however deep it is -- at `--min-reads 30` the mean consensus is 204 nt against a
+# ~508 nt amplicon. What makes the contig recoverable is that DIFFERENT molecules start at
+# different positions, so a cell's molecules tile the transcript. The ceiling column of this table
+# is that premise, scored directly: the share of each Cell Ranger contig's 25-mers present
+# anywhere in its own cell's raw molecules, before any assembly. It is 0.999.
+#
+# Never: `each ingredient is measured by removing it, in this table, on this data`. The rows are
+# the ablations, and CDR3-exact reads 0.9894 with everything on, 0.9820 without the phasing and
+# 0.9618 without the adapter trim; chain recall 0.9777 / 0.9714 / 0.9491. Note the adapter row's
+# contig N50 is the HIGHEST of the three (580 against 536) and its accuracy is the lowest -- a
+# longer contig built across an adapter is a longer wrong contig, so N50 is a description and
+# never a score. Depth weighting is the third ingredient and has no flag to turn off; it is
+# measured in `arda.singlecell`'s own module table, at 0.967 against 0.988.
+#
+# Never: `a doublet is two chains of the same LOCUS`. One TRA and one TRB in a cell is a normal
+# paired T cell. Two TRB is the doublet signal, and until the phasing landed it was invisible by
+# construction: the two chains share their constant region, so the layout puts them in one
+# component and the column consensus averages their junctions into a sequence that is neither.
+#
+# Never: `Cell Ranger is not re-run here`. The comparator is 10x's published output (5.0.0) and
+# the local 10.1.0 run; both are inputs. See docs/single_cell.rst for the cost axis.
+#
+# Usage:
+#     python scripts/compare_cellranger_contigs.py \
+#         --consensus /tmp/cr/asm_all/PBMC.consensus.fq.gz \
+#         --cellranger-dir ~/data/10x/sc5p_v2_hs_PBMC_1k_t_cellranger \
+#         --arda ~/vcs/code/arda/.venv/bin/arda \
+#         --out /tmp/cr/contigs --tsv assets/cellranger_contigs.tsv
+#
+# The consensus comes from, with EVERY molecule kept -- a shallow molecule is one more window of
+# the tiling and `--min-reads` throws the tiling away:
+#     migec assemble <refined.fq.gz> -o asm_all/ --contig --min-reads 1
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import json
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+K = 25
+_COMP = str.maketrans("ACGTN", "TGCAN")
+
+
+def rc(seq: str) -> str:
+    return seq.translate(_COMP)[::-1]
+
+
+def read_fasta(path: Path) -> dict[str, list[str]]:
+    """cell -> its sequences, for a FASTA named either `<cell>_contig_<n>` or `<cell>-1_contig_n`."""
+    out: dict[str, list[str]] = defaultdict(list)
+    name, buf = None, []
+    opener = gzip.open if path.suffix == ".gz" else open
+    with opener(path, "rt") as fh:
+        for line in fh:
+            if line.startswith(">"):
+                if name:
+                    out[name].append("".join(buf))
+                name = line[1:].split()[0].split("_contig")[0].split("-")[0]
+                buf = []
+            elif line.strip():
+                buf.append(line.strip().upper())
+    if name:
+        out[name].append("".join(buf))
+    return out
+
+
+def cellranger_contigs(fasta: Path, annotations: Path) -> tuple[dict, dict]:
+    """(cell -> contig sequences, cell -> [(chain, cdr3_nt, cdr3_aa)]), `is_cell` filtered."""
+    contigs = read_fasta(fasta)
+    calls: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    with open(annotations, newline="") as fh:
+        for row in csv.DictReader(fh):
+            if str(row.get("is_cell", "true")).strip().lower() != "true":
+                continue
+            nt = (row.get("cdr3_nt") or "").strip()
+            aa = (row.get("cdr3") or "").strip()
+            if nt and nt != "None":
+                calls[row["barcode"].split("-")[0]].append((row["chain"], nt, aa))
+    return contigs, calls
+
+
+def read_migec_molecules(consensus: Path, cells: set[str]) -> dict[str, list[str]]:
+    """cell -> its molecule consensus sequences, restricted to the called cells."""
+    out: dict[str, list[str]] = defaultdict(list)
+    with gzip.open(consensus, "rt") as fh:
+        for header, seq, _plus, _qual in zip(*[iter(fh)] * 4):
+            if header[:1] != "@":
+                continue
+            cell = header[1:].split(None, 1)[0].split(".")[1]
+            if cell in cells:
+                out[cell].append(seq.strip().upper())
+    return out
+
+
+def kmer_coverage(target: str, pool: set[str]) -> float:
+    """Share of `target`'s k-mers present in `pool`. A single mismatch costs 25 of them, so this
+    is a strict measure of sequence agreement and not merely of overlap."""
+    kmers = [target[i:i + K] for i in range(len(target) - K + 1)]
+    if not kmers:
+        return 0.0
+    return sum(1 for x in kmers if x in pool) / len(kmers)
+
+
+def kmers_of(sequences: list[str]) -> set[str]:
+    pool: set[str] = set()
+    for seq in sequences:
+        for orientation in (seq, rc(seq)):
+            for i in range(len(orientation) - K + 1):
+                pool.add(orientation[i:i + K])
+    return pool
+
+
+def score(cellranger: tuple[dict, dict], ours: dict[str, list[str]]) -> dict:
+    """k-mer coverage of each Cell Ranger contig, and exact CDR3 containment, per chain."""
+    contigs, calls = cellranger
+    coverage: list[float] = []
+    cdr3_hit: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    for cell, targets in contigs.items():
+        pool = kmers_of(ours.get(cell, []))
+        joined = [o for seq in ours.get(cell, []) for o in (seq, rc(seq))]
+        for target in targets:
+            coverage.append(kmer_coverage(target, pool))
+        for chain, nt, _aa in calls.get(cell, []):
+            found = any(nt in o for o in joined)
+            cdr3_hit[chain][0] += found
+            cdr3_hit[chain][1] += 1
+    total = [sum(v[0] for v in cdr3_hit.values()), sum(v[1] for v in cdr3_hit.values())]
+    return {
+        "contigs_scored": len(coverage),
+        "kmer_coverage_mean": sum(coverage) / len(coverage) if coverage else float("nan"),
+        "contigs_at_90pct": sum(1 for x in coverage if x >= 0.9),
+        "cdr3_exact": total[0],
+        "cdr3_total": total[1],
+        "cdr3_exact_rate": total[0] / total[1] if total[1] else float("nan"),
+        "per_chain": {k: v for k, v in sorted(cdr3_hit.items())},
+    }
+
+
+def run_arda(arda: str, consensus: Path, out: Path, cells_file: Path, reference: Path,
+             extra: list[str], threads: int) -> dict:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [arda, "cells", str(consensus), "-p", str(out), "--cells", str(cells_file),
+           "--reference", str(reference), "--threads", str(threads), *extra]
+    subprocess.run(cmd, check=True)
+    return json.loads(Path(str(out) + ".arda.json").read_text())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--consensus", type=Path, required=True,
+                    help="migec assemble --contig --min-reads 1 output")
+    ap.add_argument("--cellranger-dir", type=Path, required=True)
+    ap.add_argument("--arda", default=shutil.which("arda") or "arda")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--tsv", type=Path)
+    ap.add_argument("--threads", type=int, default=8)
+    ap.add_argument("--cellranger-version", default="5.0.0")
+    args = ap.parse_args()
+
+    directory = args.cellranger_dir.expanduser()
+    fasta = next(iter(sorted(directory.glob("*filtered_contig.fasta"))), None)
+    annotations = next(iter(sorted(directory.glob("*filtered_contig_annotations.csv"))), None)
+    if fasta is None or annotations is None:
+        raise SystemExit(
+            f"{directory} holds no *filtered_contig.fasta and *filtered_contig_annotations.csv "
+            f"pair -- the contig axis needs the SEQUENCES, not only the annotation table")
+
+    contigs, calls = cellranger_contigs(fasta, annotations)
+    if not contigs:
+        raise SystemExit(f"{fasta} yielded no contigs; the barcode naming is not what is assumed")
+    print(f"cellranger {args.cellranger_version}: {len(contigs)} cells, "
+          f"{sum(len(v) for v in contigs.values())} contigs, "
+          f"{sum(len(v) for v in calls.values())} CDR3 calls", file=sys.stderr)
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    cells_file = args.out / "cells.txt"
+    cells_file.write_text("\n".join(sorted(contigs)) + "\n")
+
+    molecules = read_migec_molecules(args.consensus, set(contigs))
+    if not molecules:
+        raise SystemExit(
+            f"none of Cell Ranger's {len(contigs)} barcodes appears in {args.consensus}. "
+            f"The consensus names must be migec's <sample>.<cell>.<umi>, and the run must not "
+            f"have been restricted by --min-reads")
+    print(f"migec: {sum(len(v) for v in molecules.values())} molecules over "
+          f"{len(molecules)} of those cells", file=sys.stderr)
+
+    rows: list[dict] = []
+
+    # The premise, scored before any assembly runs: is the contig already in the molecules?
+    ceiling = score((contigs, calls), molecules)
+    rows.append({"method": "migec molecules (no assembly)", "variant": "ceiling",
+                 "cells": len(molecules), **{k: v for k, v in ceiling.items()
+                                             if k != "per_chain"},
+                 "contig_n50": 0, "chain_recall": float("nan"),
+                 "doublet_candidates": 0, "wall_note": "k-mer ceiling, not a method"})
+
+    variants = [("arda cells", "default", []),
+                ("arda cells", "no phasing", ["--no-split"]),
+                ("arda cells", "no adapter trim", ["--no-trim-adapter"])]
+    for method, variant, extra in variants:
+        prefix = args.out / ("arda_" + variant.replace(" ", "_"))
+        report = run_arda(args.arda, args.consensus, prefix, cells_file, annotations,
+                          extra, args.threads)
+        assembled = read_fasta(Path(str(prefix) + ".contigs.fasta"))
+        scored = score((contigs, calls), assembled)
+        rows.append({
+            "method": method, "variant": variant, "cells": report["cells"],
+            **{k: v for k, v in scored.items() if k != "per_chain"},
+            "contig_n50": report["contig_n50"],
+            "chain_recall": report.get("reference_recall", float("nan")),
+            "doublet_candidates": report["cells_doublet_candidate"],
+            "wall_note": f"{report['contigs']} contigs from {report['molecules_in']} molecules",
+        })
+        if variant == "default":
+            for chain, (hit, total) in sorted(scored["per_chain"].items()):
+                print(f"  {chain}: CDR3 exact {hit}/{total} ({hit / total:.4f})", file=sys.stderr)
+
+    columns = ("method", "variant", "cells", "contigs_scored", "kmer_coverage_mean",
+               "contigs_at_90pct", "cdr3_exact", "cdr3_total", "cdr3_exact_rate",
+               "contig_n50", "chain_recall", "doublet_candidates", "wall_note")
+    lines = ["\t".join(columns)]
+    for row in rows:
+        lines.append("\t".join(
+            f"{row[c]:.4f}" if isinstance(row[c], float) else str(row[c]) for c in columns))
+    table = "\n".join(lines) + "\n"
+    print(table)
+    if args.tsv:
+        args.tsv.write_text(table)
+        print(f"wrote {args.tsv}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/_bindings.cpp
+++ b/src/_bindings.cpp
@@ -259,7 +259,13 @@ py::dict py_run_checkout(const std::string& in_path, const std::string& in_path2
         s["over_sequenced"] = h.over_sequenced();
         s["hist_reads"] = h.reads;
         s["hist_units"] = h.units;
-        s["umi_length"] = comp.length;
+        // The counter is keyed on cell + UMI, so the composition spans the whole barcode. Report
+        // the three lengths separately rather than letting `umi_length` quietly mean the barcode:
+        // `--preset 10x-v2` would then print a 26 nt "UMI" for a 10 nt one.
+        const int cell_len = i < stats.sample_cell_length.size() ? stats.sample_cell_length[i] : 0;
+        s["cell_length"] = cell_len;
+        s["umi_length"] = comp.length - cell_len;
+        s["barcode_length"] = comp.length;
         s["total_entropy"] = comp.total_entropy();
         s["total_information"] = comp.total_information();
         s["effective_length"] = comp.effective_length();

--- a/src/checkout.cpp
+++ b/src/checkout.cpp
@@ -553,8 +553,14 @@ void process_chunk(const Chunk& c, bool paired, bool write_unmatched, int gzip_l
         const size_t s = file_of[static_cast<size_t>(r.sample)];
         bool umi_has_n = false, cell_has_n = false;
         const uint64_t umi_key = pack_barcode(r.umi, &umi_has_n);
+        const uint64_t cell_key = r.cell.empty() ? 0 : pack_barcode(r.cell, &cell_has_n);
+        // The molecule's whole key, cell then UMI, which is what `refine` and `assemble` group on.
+        // `pack_barcode` puts base 0 in the top bits, so shifting the UMI down by the cell's width
+        // lands it exactly where `pack_barcode(cell + umi)` would -- without the concatenation,
+        // which would be an allocation per read.
+        const uint64_t mol_key =
+            r.cell.empty() ? umi_key : (cell_key | (umi_key >> (2 * r.cell.size())));
         if (mig.on) {
-            const uint64_t cell_key = r.cell.empty() ? 0 : pack_barcode(r.cell, &cell_has_n);
             MigStaged st;
             st.cell = cell_key;
             st.umi = umi_key;
@@ -591,7 +597,7 @@ void process_chunk(const Chunk& c, bool paired, bool write_unmatched, int gzip_l
             append_fastq(w.out1[s], name1, tags, r.seq1, r.qual1);
             if (paired) append_fastq(w.out2[s], name2, tags, r.seq2, r.qual2);
         }
-        w.umis.emplace_back(static_cast<uint32_t>(s), umi_key);
+        w.umis.emplace_back(static_cast<uint32_t>(s), mol_key);
     }
     // The per-sample buffers are empty in `.mig` mode -- nothing was formatted -- but unmatched
     // reads are FASTQ either way: they have no barcode, so there is no bucket to put them in.
@@ -637,14 +643,22 @@ CheckoutStats run_checkout(const PatternSet& patterns, const CheckoutParams& par
             file_of[i] = static_cast<uint32_t>(stats.sample_ids.size());
             stats.sample_ids.push_back(ids[i]);
             row_of_file.push_back(i);
-            stats.umi_counts.emplace_back(patterns.umi_length(i));
+            // Never: the counter is keyed on the WHOLE barcode -- cell then UMI -- not on the UMI
+            // alone. A molecule is sample + cell + UMI; UMIs repeat across cells by design, so a
+            // UMI-keyed counter merges every cell's copy of one UMI into a single entry. On a 10x
+            // library that read 221,026 distinct barcodes where there are 311,962 molecules, which
+            // put the depth 1.41x high and the space 21% occupied against a true 3e-6 -- so the
+            // saturation warning and `err_unreliable` fired on an artefact of the pooling.
+            stats.umi_counts.emplace_back(patterns.cell_length(i) + patterns.umi_length(i));
+            stats.sample_cell_length.push_back(patterns.cell_length(i));
         } else {
             file_of[i] = static_cast<uint32_t>(it - stats.sample_ids.begin());
-            // The rows would otherwise write UMIs of two lengths into one counter, and the
+            // The rows would otherwise write barcodes of two lengths into one counter, and the
             // composition, the collision statistics and the correction would all be nonsense.
-            if (patterns.umi_length(i) != stats.umi_counts[file_of[i]].length()) {
+            if (patterns.cell_length(i) + patterns.umi_length(i) !=
+                stats.umi_counts[file_of[i]].length()) {
                 throw MigecError("checkout: sample '" + ids[i] +
-                                 "' is declared with two different UMI lengths");
+                                 "' is declared with two different barcode lengths");
             }
         }
     }

--- a/src/consensus.cpp
+++ b/src/consensus.cpp
@@ -332,10 +332,15 @@ bool seed_offset(const ConsensusRead& a, const ConsensusRead& b, const Consensus
     const int k = params.seed_length;
     const int la = read_length(a), lb = read_length(b);
     if (la < k || lb < k) return false;
-    // ponytail: a plain map of seed -> first position, and O(n^2) pairs per group. Contig mode
-    // runs on random-primed data where a barcode carries a handful of reads (X1: 1.5% of 10x
-    // groups hold more than one), so the quadratic is over single digits. Index the group once if
-    // a benchmark ever puts hundreds of reads on one barcode.
+    // ponytail: a plain map of seed -> first position, rebuilt per pair. The comment here used to
+    // say the quadratic was "over single digits" because X1 found only 1.5% of 10x groups hold
+    // more than one read -- that is true of ALL groups and false of the ones contig mode is run
+    // on. Measured on `sc5p_v2_hs_PBMC_1k` at `--min-reads 30`: 47,584 molecules averaging 110
+    // reads, the deepest 802. The named ceiling was reached, so the upgrade path was taken -- but
+    // in `place_reads`, by not asking about pairs union-find has already joined, which is exact
+    // and was worth 19.7x. Indexing the group once is the remaining move and is NOT taken: after
+    // the short-circuit the seed scan runs O(components) times per group, not O(reads^2), so
+    // there is no longer a benchmark that justifies it.
     std::unordered_map<std::string_view, int> seeds;
     seeds.reserve(static_cast<size_t>(la - k + 1));
     for (int i = 0; i <= la - k; ++i) {
@@ -361,8 +366,24 @@ bool seed_offset(const ConsensusRead& a, const ConsensusRead& b, const Consensus
 std::vector<std::vector<ConsensusRead>> place_reads(const std::vector<ConsensusRead>& reads,
                                                     const ConsensusParams& params) {
     OffsetUnion uf(reads.size());
+    // Two reads already in one component cannot change the partition, and `join` says so itself --
+    // it returns immediately when the roots match. Asking union-find FIRST is therefore exactly
+    // equivalent and skips the seed scan, which is the expensive half: the pairs it skips are
+    // precisely the ones whose answer `join` would have thrown away.
+    //
+    // This is the common case, not a corner. Reads of one (CB, UMI) are co-terminal in 92% of 10x
+    // groups, so a molecule is a PILE that closes into one component after a handful of joins and
+    // then spends the rest of an 800-read quadratic re-deriving it. Measured on 47,584 molecules
+    // of `sc5p_v2_hs_PBMC_1k`: 640.9 s -> 32.6 s, consensus FASTQ and `mig.tsv` byte-identical.
+    //
+    // ponytail: breaking out of the loop entirely once one component holds every read is also
+    // exact, and was measured at 33.4 s against 32.6 -- nothing, because what remains after the
+    // short-circuit is path-compressed `find` calls at a few ns. Not taken; the ceiling it would
+    // bound is a single group at the 10,000-read cap, and no benchmark asks for it.
     for (size_t i = 0; i < reads.size(); ++i) {
         for (size_t j = i + 1; j < reads.size(); ++j) {
+            int oi = 0, oj = 0;
+            if (uf.find(static_cast<int>(i), oi) == uf.find(static_cast<int>(j), oj)) continue;
             int shift = 0;
             // seed_offset returns offset(j) - offset(i), so join(j, i, shift).
             if (seed_offset(reads[i], reads[j], params, shift)) {

--- a/src/refine.cpp
+++ b/src/refine.cpp
@@ -731,10 +731,23 @@ RefineStats refine(const RefineRequest& request) {
             const uint32_t robust_max = sizes[std::min(at, top - 1)];
             stats.cell_threshold = std::max<uint32_t>(1, robust_max / 10);
 
-            // The knee, reported next to it rather than instead of it: the rank furthest from the
-            // chord joining the first and last points of the log-log curve. It is a description of
-            // the data; OrdMag is the rule that makes the call, and when the two disagree badly
-            // that is worth seeing.
+            // The knee, reported next to the threshold rather than instead of it: the rank
+            // furthest from the chord joining the first and last points of the log-log curve.
+            // It is a description of the data; OrdMag is the rule that makes the call, and when
+            // the two disagree badly that is worth seeing.
+            //
+            // Note: this IS Kneedle (Satopaa 2011), taken at the GLOBAL maximum of its difference
+            // curve. Distance to the endpoint chord and Kneedle's normalised |y_n - (1 - x_n)|
+            // are the same quantity up to a constant on a decreasing curve; what differs is the
+            // selection rule. Kneedle as published walks the LOCAL maxima and stops at the first
+            // one that then falls by a sensitivity step, and that rule needs the smoothing spline
+            // the paper specifies. Measured on this library's 136,032 barcodes: unsmoothed, the
+            // difference curve has 287 local maxima and the walk stops at rank 15 (1,057
+            // molecules) -- it would call fifteen cells. Smoothed over a 0.01 window in
+            // normalised log-rank it gives rank 358 (314 molecules), which is the global maximum
+            // here (rank 376, 308 molecules) to within 5%, and over-smoothing drifts it back off
+            // (rank 180 at a 0.1 window). The global maximum reaches the same answer with no
+            // smoothing parameter to tune, so it is what we keep.
             if (sizes.size() > 2) {
                 const double x0 = 0.0, y0 = std::log10(static_cast<double>(sizes.front()));
                 const double x1 = std::log10(static_cast<double>(sizes.size()));
@@ -749,6 +762,28 @@ RefineStats refine(const RefineRequest& request) {
                         stats.knee_rank = i + 1;
                         stats.knee_molecules = sizes[i];
                     }
+                }
+                // The guard, and it is not decoration. A global maximum always exists, so the
+                // difference curve returns a rank on a library that has no cells in it at all --
+                // and reporting that beside OrdMag reads as two methods disagreeing about where
+                // the cells are, rather than as a curve with no knee in it.
+                //
+                // The floor is ONE ORDER OF MAGNITUDE above the mean molecules per observed
+                // barcode, which is the unit a log-log curve is actually read in. The mean alone
+                // is too weak and was tried: an ambient-only library of 1-3 molecules per barcode
+                // is a step curve whose corner sits at 3 against a mean of 2.0, clears a
+                // mean-only test at 1.5x, and is meaningless. Measured on `sc5p_v2_hs_PBMC_1k`,
+                // where the knee IS real: 308 molecules against a mean of 3.44, a factor of 89.
+                // The two cases are two orders apart, so the boundary is not a tuned one.
+                //
+                // 0 means "no knee": `refine.py` prints it as such and the OrdMag-vs-knee
+                // disagreement warning already skips a zero.
+                double total = 0.0;
+                for (uint32_t v : sizes) total += static_cast<double>(v);
+                const double mean_molecules = total / static_cast<double>(sizes.size());
+                if (static_cast<double>(stats.knee_molecules) < 10.0 * mean_molecules) {
+                    stats.knee_rank = 0;
+                    stats.knee_molecules = 0;
                 }
             }
             for (uint32_t v : sizes) {

--- a/tests/realworld/test_cellranger.py
+++ b/tests/realworld/test_cellranger.py
@@ -1,0 +1,81 @@
+"""The Cell Ranger side of `scripts/compare_cellranger.py`, asserted on its own.
+
+Only the comparator is checked here, not migec: the published Cell Ranger 5.0.0 output for
+`sc5p_v2_hs_PBMC_1k` VDJ-T is small, committed nowhere, and fetched on demand, while migec's side
+needs the 1.1 GB FASTQ pair. What this tier is for is catching the day 10x reissue the files or
+change a column's meaning -- which is exactly the failure the script's read-back exists to refuse,
+so the read-back itself is what gets tested.
+
+Note: the CI fixture is a 1% cell subsample and CANNOT show cell calling with a knee, so nothing
+here asserts a migec cell count. That belongs on the full library.
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+BASE = ("https://cf.10xgenomics.com/samples/cell-vdj/5.0.0/sc5p_v2_hs_PBMC_1k/"
+        "sc5p_v2_hs_PBMC_1k_t")
+FILES = ("filtered_contig_annotations.csv", "airr_rearrangement.tsv", "metrics_summary.csv")
+
+
+@pytest.fixture(scope="module")
+def published(tmp_path_factory):
+    """10x's own Cell Ranger 5.0.0 output, fetched once. Skips when offline."""
+    d = tmp_path_factory.mktemp("cellranger")
+    for name in FILES:
+        # cf.10xgenomics.com answers 403 to urllib's default User-Agent but serves curl's, so the
+        # header is required rather than polite -- without it every test here skips and the suite
+        # reports green having checked nothing.
+        req = urllib.request.Request(f"{BASE}_{name}", headers={"User-Agent": "curl/8"})
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                (d / f"sc5p_v2_hs_PBMC_1k_t_{name}").write_bytes(r.read())
+        except OSError as exc:
+            pytest.skip(f"cannot reach cf.10xgenomics.com: {exc}")
+    return d
+
+
+def test_the_cell_set_is_the_one_the_comparison_was_scored_against(published):
+    from compare_cellranger import CELLRANGER_CELLS, CELLRANGER_CONTIGS, read_cellranger_cells
+
+    cells, contigs = read_cellranger_cells(
+        published / "sc5p_v2_hs_PBMC_1k_t_filtered_contig_annotations.csv")
+    assert len(cells) == CELLRANGER_CELLS
+    assert contigs == CELLRANGER_CONTIGS
+    assert all(len(b) == 16 and set(b) <= set("ACGTN") for b in cells)
+
+
+def test_is_cell_actually_filters(published):
+    """`_all_contig_annotations` spans 699 barcodes; reading it unfiltered inflates the set 46%."""
+    path = published / "sc5p_v2_hs_PBMC_1k_t_filtered_contig_annotations.csv"
+    with open(path, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    assert {r["is_cell"].strip().lower() for r in rows} == {"true"}
+
+
+def test_the_airr_count_columns_still_mean_what_the_script_assumes(published):
+    """consensus_count is READS and duplicate_count is UMIs -- the inverse of arda's spelling.
+
+    This is the one that would corrupt a join silently, so it is the one with a test.
+    """
+    from compare_cellranger import check_airr_counts
+
+    check_airr_counts(published / "sc5p_v2_hs_PBMC_1k_t_airr_rearrangement.tsv",
+                      published / "sc5p_v2_hs_PBMC_1k_t_filtered_contig_annotations.csv")
+
+
+def test_the_headline_metrics_are_the_ones_quoted_in_the_docs(published):
+    from compare_cellranger import _pct, read_metrics
+
+    m = read_metrics(published / "sc5p_v2_hs_PBMC_1k_t_metrics_summary.csv")
+    assert _pct(m["Valid Barcodes"]) == pytest.approx(0.906)
+    assert _pct(m["Fraction Reads in Cells"]) == pytest.approx(0.868)
+    assert int(m["Number of Read Pairs"].replace(",", "")) == 6_301_573

--- a/tests/synthetic/test_assemble.py
+++ b/tests/synthetic/test_assemble.py
@@ -213,6 +213,33 @@ def test_contig_mode_assembles_tiled_reads_into_one_contig(tmp_path):
         assert fh.readline().rstrip("\n") == molecule
 
 
+def test_contig_placement_is_unchanged_by_the_already_joined_shortcut(tmp_path):
+    """A deep PILE is the common case, and it is what `place_reads` short-circuits on.
+
+    Reads of one (CB, UMI) are co-terminal in 92% of 10x groups, so the overlap component closes
+    after the first few joins and every remaining pair is scanned to learn something union-find
+    already knows. Skipping those pairs is exactly equivalent -- `join` returns immediately when
+    the roots match -- and took a real 47,584-molecule run from 640.9 s to 32.6 s with a
+    byte-identical consensus. What this asserts is the equivalence, on a group that mixes a deep
+    pile with a tiling so both branches of the shortcut are taken.
+    """
+    import random
+
+    rng = random.Random(11)
+    molecule = "".join(rng.choice("ACGT") for _ in range(300))
+    # Sixteen reads at offset 0 (the pile), plus a tiling that has to still reach 300 nt.
+    offsets = [0] * 16 + [30, 60, 90, 120, 150, 180, 210]
+    reads = tmp_path / "pile.fq"
+    reads.write_text(_tiled(molecule, offsets, 90))
+
+    summary = run(reads, tmp_path / "asm", sample_id="S1", contig=True)
+    assert summary["groups"] == 1
+    assert summary["molecules"] == 1, "the pile and the tiling are one overlap component"
+    with gzip.open(tmp_path / "asm" / "S1.consensus.fq.gz", "rt") as fh:
+        fh.readline()
+        assert fh.readline().rstrip("\n") == molecule
+
+
 def test_contig_mode_never_bridges_a_gap(tmp_path):
     """Two islands of reads sharing a barcode but no sequence are two contigs. A single consensus
     over them would assert 100 nt that no read covers."""

--- a/tests/synthetic/test_dual_end.py
+++ b/tests/synthetic/test_dual_end.py
@@ -128,6 +128,37 @@ def test_a_positional_barcode_read_with_no_payload_is_not_dropped(tmp_path):
     assert len(tags["RX"]) == 10
 
 
+def test_the_skew_warning_is_weighed_against_the_barcode_not_the_umi(tmp_path):
+    """The counter is keyed on cell + UMI, so `effective_length` spans 26 nt, not 10.
+
+    Weighed against `umi_length` the test reads "25.4 nt of a 10 nt UMI is usable" and can never
+    be true, so the warning is dead on every single-cell run -- which is exactly where a skewed
+    cell barcode is worth hearing about. Here the first eight positions of the cell barcode are
+    constant, so about 18 of 26 barcode bases carry information: below 0.8 x 26, above 0.8 x 10.
+    """
+    with gzip.open(tmp_path / "r1.fq.gz", "wt") as f1, gzip.open(tmp_path / "r2.fq.gz", "wt") as f2:
+        rng = random.Random(3)
+        for i in range(500):
+            cb = "A" * 8 + "".join(rng.choice("ACGT") for _ in range(8))
+            umi = "".join(rng.choice("ACGT") for _ in range(10))
+            cdna = "".join(rng.choice("ACGT") for _ in range(90))
+            f1.write(f"@r{i}\n{cb}{umi}\n+\n{'I' * 26}\n")
+            f2.write(f"@r{i}\n{cdna}\n+\n{'I' * 90}\n")
+    (tmp_path / "bc.txt").write_text(f"P\t{TENX}\n")
+
+    s = run(tmp_path / "r1.fq.gz", tmp_path / "bc.txt", tmp_path / "out",
+            reads2=tmp_path / "r2.fq.gz", max_offset=0)["samples"][0]
+    # The three lengths are reported apart, so nothing has to guess which one a column means.
+    assert (s["umi_length"], s["cell_length"], s["barcode_length"]) == (10, 16, 26)
+    assert s["umi_length"] < s["effective_length"] < s["barcode_length"]
+
+    from migec.checkout import format_report
+
+    report = format_report(run(tmp_path / "r1.fq.gz", tmp_path / "bc.txt", tmp_path / "out2",
+                               reads2=tmp_path / "r2.fq.gz", max_offset=0))
+    assert "barcode is 26 nt but only" in report
+
+
 def test_a_positional_pattern_is_refused_by_a_free_scan(tmp_path):
     """No anchor means nothing to search for. Saying so beats matching everywhere.
 

--- a/tests/synthetic/test_refine.py
+++ b/tests/synthetic/test_refine.py
@@ -331,6 +331,33 @@ def test_the_knee_is_reported_next_to_the_call_not_instead_of_it(tmp_path):
     assert max(s["knee_rank"], s["cells_called"]) < 3 * min(s["knee_rank"], s["cells_called"])
 
 
+def test_a_curve_with_no_cells_in_it_reports_no_knee(tmp_path):
+    """The guard the knee needs, and the reason it is not decoration.
+
+    A library that is ambient and nothing else has no knee. Taking the global maximum of the
+    difference curve anyway always returns SOME rank, and reporting it beside OrdMag reads as two
+    methods disagreeing about where the cells are rather than as a curve with no cells in it. The
+    knee is refused when it sits at or below the mean molecules per observed barcode, which is
+    exactly the regime where its threshold would call every barcode a cell.
+    """
+    reads = tmp_path / "flat.fq.gz"
+    _droplets(reads, 0, (1, 1), 4_000, (1, 3), seed=7)
+    s = run(reads, tmp_path / "ref", expect_cells=400)
+    assert s["cells_observed"] > 1_000
+    assert s["knee_rank"] == 0
+    assert s["knee_molecules"] == 0
+
+
+def test_a_clean_library_still_reports_its_knee(tmp_path):
+    """The other half of the guard: it must not eat a real knee. Same fixture as the calling test,
+    where the separation is wide and the knee sits two orders above the ambient mean."""
+    reads = tmp_path / "d.fq.gz"
+    _droplets(reads, 400, (300, 900), 10_000, (1, 2), seed=1)
+    s = run(reads, tmp_path / "ref", expect_cells=400)
+    assert s["knee_rank"] > 0
+    assert s["knee_molecules"] > s["molecules"] / max(s["cells_observed"], 1)
+
+
 def test_expect_cells_being_wrong_does_not_move_the_call_much(tmp_path):
     """OrdMag takes the 99th percentile of the top N, so over-stating N by 400x still lands the
     index inside the real cells. That robustness is the reason the rule is worth having, and it


### PR DESCRIPTION
## What is in it

**A molecule is sample + cell + UMI, and `checkout`'s counters were keyed on the UMI alone.** On `sc5p_v2_hs_PBMC_1k` that read 221,026 pooled UMIs where there are 311,962 molecules, put the depth 1.41x high, and fired the saturation warning at an apparent 21% occupancy against a true 3e-6. The key is now cell then UMI.

The follow-through: `effective_length` is measured over the whole barcode, so weighing it against the 10 nt UMI made the composition-skew warning unable to fire on any single-cell run. It is weighed against `barcode_length` now, and `checkout.summary.tsv` carries all three lengths.

**The Cell Ranger axis**, which found the above: cells, per-cell chains and reference-free contigs, against both 5.0.0 (published) and 10.1.0 (run here) — the two agree at Jaccard 0.9938, which is the control saying the migec gap is not version drift.

**The knee is Kneedle at its global maximum and now refuses when there is no knee.** The published local-maxima walk is degenerate without the paper's smoothing spline (287 local maxima, stops at fifteen cells). Guarded at 10x the mean molecules per barcode.

**`place_reads` asks union-find before it scans: 640.9 s -> 32.6 s, byte-identical output** over 47,584 molecules. Exact, not a heuristic.

## Verification

- `ctest`: 1/1 passed
- `pytest tests/unit tests/synthetic`: 327 passed, 1 skipped (minibwa not on PATH)
- `ruff check python/ tests/ scripts/`: clean
- `sphinx-build -W --keep-going`: clean from a wiped `_build`
- `scripts/wheel_smoke.sh`: ok
- version agrees in all three places

Regression test for the unit mismatch is in `tests/synthetic/test_dual_end.py`: a cell barcode with eight constant positions gives 17.93 usable bases of 26, which fires the warning and would not have fired the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)