### PR TITLE
Guard the packed barcode key, and index seeds once per read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ prevents. Releases before 2.0.0 are the Groovy MIGEC and are described by their 
 
 ## Unreleased
 
+### A barcode too long for the key is refused, and the shift that packs it is guarded
+
+`checkout` validated the cell and UMI lengths **apart** and grouped molecules on their **sum**.
+20 nt of cell and 16 of UMI each clear their own 32-base bound; their 36 nt total does not fit the
+64-bit key at all, so two molecules sharing their first 32 bases packed identically and merged.
+Measured before the guard: **1 distinct barcode where there were 2** — the error nothing
+downstream can detect. Refused now when the pattern compiles, where the offending row of the
+barcode table can still be named.
+
+Never: **a dual-end sample is checked across both mates.** The slave pattern extends the UMI on
+the other mate, so no single `compile` call can see the total; 16 + 12 + 12 = 40 is three
+individually legal parts. The check is in `PatternSet::add`, the last place the row is still the
+unit.
+
+Never: **`>> 64` on a 64-bit key is undefined, not zero.** x86 masks the shift count to 6 bits, so
+it becomes `>> 0` and the UMI is ORed back on top of the cell barcode instead of below it. A 32 nt
+cell barcode with no UMI reaches it, and the length check above permits that layout because 32 + 0
+fits exactly. Confirmed under UBSan that the old expression is flagged and returns a *different*
+value from the guarded one.
+
+### `place_reads` builds each read's seed index once, not once per pair
+
+**40,786 -> 150,152 reads/s (3.7x) on 60 groups of 500 reads, with the consensus FASTQ and
+`mig.tsv` MD5-identical.** The union-find short-circuit released in 2.5.0 cut the scan count from
+O(reads²) to O(reads x components) — but 8% of 10x reads are not co-terminal, so a 500-read group
+carries ~40 components and read 0 was rebuilding its own seed map once for each of them. The index
+is now built once per read and lazily, so a pure pile never builds one at all. Same computation,
+cached; the partition and the offsets are unchanged.
+
+Never: **the persistent worker pool named as `kChunkReads`' upgrade path cannot deliver the 32%,
+and that claim had never been measured.** `parallel_for`'s whole per-call cost is ~140 us at 16
+threads and is flat in the item count, so only the call count pays it: 0.069 s at 8 k chunks
+against 0.009 s at 64 k. That 0.060 s is **14% of the 0.42 s** the chunk change is worth on 4 M
+reads — about 3% of the run — and a pool removes exactly that term and nothing else. The rest is
+the serial read and the barrier tail. The measurement is written down beside the constant.
+
 ## 2.5.0 — 2026-08-15
 
 ### The knee is Kneedle, and it now refuses to answer when there is no knee

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,8 +510,15 @@ rebuild the old tag.
   because `parallel_for` starts and joins its threads per call and 4 M reads at 8 k pays ~15,000
   thread creations. Not taken: 16 MB of resident chunk makes **pass 1** the memory peak on a finely
   partitioned shallow library, breaking "a finer partition costs less, not more" --
-  `test_shallow_memory_is_still_bounded_by_the_bucket` is what caught it. The upgrade path is a
-  persistent worker pool, not a bigger chunk.
+  `test_shallow_memory_is_still_bounded_by_the_bucket` is what caught it.
+- **Never: the persistent worker pool this file used to name as that upgrade path CANNOT pay for
+  it, and the claim had never been measured (2026-08-15).** `parallel_for`'s entire per-call cost
+  -- spawn, join and all -- is **~140 us at 16 threads and FLAT in the item count**, so only the
+  call count pays it: 488 calls at 8 k costs 0.069 s against 61 calls at 64 k costing 0.009 s.
+  That **0.060 s is 14% of the 0.42 s** the chunk change is worth on 4 M reads, i.e. ~3% of the
+  run, and a pool removes that term and nothing else -- the other 86% is the serial read and the
+  barrier tail. Measure the helper before rewriting it; the number is in `src/assemble.cpp` beside
+  `kChunkReads`.
 - **`subsample` reports what it kept (2.0.0a4)**: median and deepest reads per kept barcode next to
   the mean, plus five example barcodes with their depths. Never: **in key order, not first-seen
   order** -- a 100-read barcode appears early ~100x more often than a singleton, so the head of a

--- a/src/assemble.cpp
+++ b/src/assemble.cpp
@@ -209,9 +209,16 @@ AssembleStats assemble(const AssembleRequest& in) {
         // memory peak, which breaks the property that a finer partition costs less, not more.
         // `test_shallow_memory_is_still_bounded_by_the_bucket` is the guard, and it does not fail
         // at 64 k on a 500 k-read corpus -- the objection is one of scale, not one the test tier
-        // can see, which is exactly why the constant is written down here with its number. The
-        // upgrade path is a persistent worker pool rather than a bigger chunk: with the threads
-        // started once for the whole pass, chunk size stops buying anything and can stay small.
+        // can see, which is exactly why the constant is written down here with its number.
+        //
+        // Never: the persistent worker pool this note used to name as the upgrade path CANNOT buy
+        // the 32%, and the claim was never measured. `parallel_for`'s whole per-call cost -- spawn,
+        // join and all -- is ~140 us at 16 threads and is FLAT in the item count, so it is the
+        // call count that pays it: 488 calls at 8 k costs 0.069 s against 61 calls at 64 k costing
+        // 0.009 s. That 0.060 s is 14% of the 0.42 s the chunk change is worth on 4 M reads, i.e.
+        // ~3% of the run, and a pool removes exactly that term and nothing else. The other 86% is
+        // the serial read and the barrier tail, which a pool does not touch. Measure the helper
+        // before rewriting it: this is the same lesson as the stale comment in `consensus.cpp`.
         constexpr size_t kChunkReads = 8192;
         // What the parallel scan extracts from a record. No strings: the serial pass that follows
         // only validates and counts, so it must not have to touch the comment again.

--- a/src/checkout.cpp
+++ b/src/checkout.cpp
@@ -558,8 +558,15 @@ void process_chunk(const Chunk& c, bool paired, bool write_unmatched, int gzip_l
         // `pack_barcode` puts base 0 in the top bits, so shifting the UMI down by the cell's width
         // lands it exactly where `pack_barcode(cell + umi)` would -- without the concatenation,
         // which would be an allocation per read.
-        const uint64_t mol_key =
-            r.cell.empty() ? umi_key : (cell_key | (umi_key >> (2 * r.cell.size())));
+        //
+        // Never: the shift is guarded rather than assumed in range. `>> 64` on a 64-bit key is
+        // UNDEFINED, not zero -- x86 masks the count to 6 bits, so it becomes `>> 0` and the UMI
+        // lands back on top of the cell barcode instead of below it. A 32 nt cell barcode with no
+        // UMI reaches it, which the length check above permits (32 + 0 fits the key exactly).
+        const unsigned shift = 2u * static_cast<unsigned>(r.cell.size());
+        const uint64_t mol_key = r.cell.empty() ? umi_key
+                                 : shift >= 64u ? cell_key
+                                                : (cell_key | (umi_key >> shift));
         if (mig.on) {
             MigStaged st;
             st.cell = cell_key;

--- a/src/consensus.cpp
+++ b/src/consensus.cpp
@@ -327,26 +327,37 @@ struct OffsetUnion {
 // The modal offset between two reads, by exact seed votes. Returns false when the evidence is too
 // thin -- no offset at all is the right answer for two reads of the same molecule that simply do
 // not overlap, and inventing one is what glues a contig across a gap.
-bool seed_offset(const ConsensusRead& a, const ConsensusRead& b, const ConsensusParams& params,
-                 int& shift) {
+// Seed -> first position in read `a`. Held by the caller so it can be built once per `a` and
+// reused against every `b`, which is what `place_reads` does; the string_views point into a.seq,
+// so it must not outlive the read it indexes.
+//
+// ponytail: still a plain hash map, and the ceiling is named. It was rebuilt PER PAIR until the
+// measurement below; the two remaining moves are a rolling hash instead of `string_view` keys and
+// a suffix automaton instead of a map, and neither has a benchmark asking for it -- after the
+// union-find short-circuit and this reuse, a 500-read group spends its time in the vote loop
+// rather than in construction. Revisit if a group ever holds thousands of components.
+using SeedIndex = std::unordered_map<std::string_view, int>;
+
+void build_seeds(const ConsensusRead& a, const ConsensusParams& params, SeedIndex& seeds) {
     const int k = params.seed_length;
-    const int la = read_length(a), lb = read_length(b);
-    if (la < k || lb < k) return false;
-    // ponytail: a plain map of seed -> first position, rebuilt per pair. The comment here used to
-    // say the quadratic was "over single digits" because X1 found only 1.5% of 10x groups hold
-    // more than one read -- that is true of ALL groups and false of the ones contig mode is run
-    // on. Measured on `sc5p_v2_hs_PBMC_1k` at `--min-reads 30`: 47,584 molecules averaging 110
-    // reads, the deepest 802. The named ceiling was reached, so the upgrade path was taken -- but
-    // in `place_reads`, by not asking about pairs union-find has already joined, which is exact
-    // and was worth 19.7x. Indexing the group once is the remaining move and is NOT taken: after
-    // the short-circuit the seed scan runs O(components) times per group, not O(reads^2), so
-    // there is no longer a benchmark that justifies it.
-    std::unordered_map<std::string_view, int> seeds;
+    const int la = read_length(a);
+    seeds.clear();
+    if (la < k) return;
     seeds.reserve(static_cast<size_t>(la - k + 1));
     for (int i = 0; i <= la - k; ++i) {
         seeds.emplace(a.seq.substr(static_cast<size_t>(i), static_cast<size_t>(k)), i);
     }
-    std::unordered_map<int, int> votes;
+}
+
+// The voting half, against an index the caller already built. `votes` is the caller's scratch for
+// the same reason the index is: it is cleared, not reallocated, once per pair.
+bool seed_offset_indexed(const SeedIndex& seeds, int la, const ConsensusRead& b,
+                         const ConsensusParams& params, std::unordered_map<int, int>& votes,
+                         int& shift) {
+    const int k = params.seed_length;
+    const int lb = read_length(b);
+    if (la < k || lb < k) return false;
+    votes.clear();
     for (int j = 0; j <= lb - k; ++j) {
         auto it = seeds.find(b.seq.substr(static_cast<size_t>(j), static_cast<size_t>(k)));
         if (it != seeds.end()) ++votes[it->second - j];
@@ -359,6 +370,14 @@ bool seed_offset(const ConsensusRead& a, const ConsensusRead& b, const Consensus
     // The implied overlap has to be long enough to be evidence rather than a repeat.
     const int overlap = std::min(shift + la, lb) - std::max(shift, 0);
     return overlap >= params.min_overlap;
+}
+
+bool seed_offset(const ConsensusRead& a, const ConsensusRead& b, const ConsensusParams& params,
+                 int& shift) {
+    SeedIndex seeds;
+    std::unordered_map<int, int> votes;
+    build_seeds(a, params, seeds);
+    return seed_offset_indexed(seeds, read_length(a), b, params, votes, shift);
 }
 
 }  // namespace
@@ -380,13 +399,27 @@ std::vector<std::vector<ConsensusRead>> place_reads(const std::vector<ConsensusR
     // exact, and was measured at 33.4 s against 32.6 -- nothing, because what remains after the
     // short-circuit is path-compressed `find` calls at a few ns. Not taken; the ceiling it would
     // bound is a single group at the 10,000-read cap, and no benchmark asks for it.
+    //
+    // Never: read i's seed index is built ONCE per i, not once per pair, and lazily so a pile that
+    // skips every j never builds one at all. The short-circuit above left the scan count at
+    // O(reads x components) rather than O(reads^2) -- and 8% of 10x reads are NOT co-terminal, so
+    // a 500-read group carries ~40 components and i=0 alone was rebuilding the same map 40 times.
+    // Indexing per i is exactly the same computation with the rebuild removed, so the partition,
+    // the offsets and the output are identical.
+    SeedIndex seeds;
+    std::unordered_map<int, int> votes;
     for (size_t i = 0; i < reads.size(); ++i) {
+        bool indexed = false;
         for (size_t j = i + 1; j < reads.size(); ++j) {
             int oi = 0, oj = 0;
             if (uf.find(static_cast<int>(i), oi) == uf.find(static_cast<int>(j), oj)) continue;
+            if (!indexed) {
+                build_seeds(reads[i], params, seeds);
+                indexed = true;
+            }
             int shift = 0;
             // seed_offset returns offset(j) - offset(i), so join(j, i, shift).
-            if (seed_offset(reads[i], reads[j], params, shift)) {
+            if (seed_offset_indexed(seeds, read_length(reads[i]), reads[j], params, votes, shift)) {
                 uf.join(static_cast<int>(j), static_cast<int>(i), shift);
             }
         }

--- a/src/pattern.cpp
+++ b/src/pattern.cpp
@@ -118,6 +118,21 @@ BarcodePattern BarcodePattern::compile(std::string_view spec) {
                          " nt cell barcode; the packed representation holds " +
                          std::to_string(kMaxBarcodeLen));
     }
+    // Never: the two lengths are checked TOGETHER as well as apart, because the key a molecule is
+    // grouped on is cell + UMI -- 20 and 16 each clear their own check and their 36 nt sum does
+    // not fit the 64-bit key at all. Two molecules sharing their first 32 bases and differing past
+    // them then pack to the SAME key and merge, which is the error nothing downstream can detect;
+    // measured before this guard, a 20+16 layout counted 1 distinct barcode where there were 2.
+    // `refine` and `assemble` already refuse the sum when they read it back off a tag, so without
+    // this the FASTQ route was the one door left open. It also keeps the shift in `process_chunk`
+    // defined: a 32 nt cell would shift a 64-bit key by 64, which is UB rather than zero.
+    if (p.cell_length_ + p.umi_length_ > kMaxBarcodeLen) {
+        throw MigecError("pattern: \"" + std::string(spec) + "\" captures a " +
+                         std::to_string(p.cell_length_) + " nt cell barcode and a " +
+                         std::to_string(p.umi_length_) + " nt UMI; a molecule is grouped on both, " +
+                         "and the packed representation holds " + std::to_string(kMaxBarcodeLen) +
+                         " bases in total");
+    }
     return p;
 }
 
@@ -287,6 +302,20 @@ void PatternSet::add(std::string sample_id, std::string_view spec, std::string_v
     } else {
         slave_of_.push_back(static_cast<int>(slaves_.size()));
         slaves_.push_back(BarcodePattern::compile(slave));
+    }
+    // `compile` checks one pattern against the key, and a dual-end sample is TWO -- the slave
+    // extends the UMI on the other mate, so the total a molecule is grouped on is the master's
+    // cell plus both UMIs, and no single compile call can see it. Checked here, where the row is
+    // still the unit and the sample id can be named; by `run_checkout` the rows have been folded
+    // by sample id and the attribution is gone.
+    const size_t i = patterns_.size() - 1;
+    if (cell_length(i) + umi_length(i) > kMaxBarcodeLen) {
+        throw MigecError("checkout: sample '" + samples_.back() + "' captures " +
+                         std::to_string(cell_length(i)) + " nt of cell barcode and " +
+                         std::to_string(umi_length(i)) +
+                         " nt of UMI across both mates; a molecule is grouped on both, and the "
+                         "packed representation holds " +
+                         std::to_string(kMaxBarcodeLen) + " bases in total");
     }
 }
 

--- a/tests/cpp/test_pattern.cpp
+++ b/tests/cpp/test_pattern.cpp
@@ -271,3 +271,28 @@ TEST_CASE("a slave pattern extends the UMI rather than starting a new one") {
     CHECK_FALSE(plain.has_slave(0));
     CHECK(plain.umi_length(0) == 12);
 }
+
+TEST_CASE("the cell and UMI lengths are checked together, not only apart") {
+    // 20 and 16 each clear their own bound and their 36 nt sum does not fit the 64-bit key at
+    // all. A molecule is grouped on cell + UMI, so before this guard two molecules sharing their
+    // first 32 bases packed to the same key and merged: measured, 1 distinct barcode where there
+    // were 2, which is the error nothing downstream can detect.
+    CHECK_THROWS_AS(BarcodePattern::compile(std::string(20, 'X') + std::string(16, 'N')),
+                    MigecError);
+    // The legal layouts are untouched, including the one that exactly fills the key.
+    CHECK_NOTHROW(BarcodePattern::compile(std::string(16, 'X') + std::string(10, 'N')));
+    CHECK_NOTHROW(BarcodePattern::compile(std::string(16, 'X') + std::string(16, 'N')));
+}
+
+TEST_CASE("a dual-end sample is checked across BOTH mates") {
+    // The slave extends the UMI on the other mate, so no single compile call can see the total.
+    // 16 nt cell + 12 + 12 = 40, and each of the three parts is individually legal.
+    PatternSet set;
+    CHECK_THROWS_AS(set.add("S1", std::string(16, 'X') + std::string(12, 'N'),
+                            std::string(12, 'N')),
+                    MigecError);
+    // ...and a dual-end sample that fits is still accepted, at exactly the bound.
+    PatternSet ok;
+    CHECK_NOTHROW(ok.add("S2", std::string(8, 'X') + std::string(12, 'N'), std::string(12, 'N')));
+    CHECK(ok.cell_length(0) + ok.umi_length(0) == 32);
+}

--- a/tests/synthetic/test_assemble.py
+++ b/tests/synthetic/test_assemble.py
@@ -240,6 +240,35 @@ def test_contig_placement_is_unchanged_by_the_already_joined_shortcut(tmp_path):
         assert fh.readline().rstrip("\n") == molecule
 
 
+def test_many_components_are_placed_the_same_with_the_seed_index_reused(tmp_path):
+    """The seed index is built once per read i, not once per pair -- same computation, cached.
+
+    The union-find short-circuit left the scan count at O(reads x components), and 8% of 10x reads
+    are not co-terminal, so a deep group carries tens of components and read 0 was rebuilding its
+    own seed map once for each of them. Measured on 60 groups of 500 reads: 40,786 -> 150,152
+    reads/s, with the consensus FASTQ and `mig.tsv` MD5-identical either way.
+
+    This fixture is the shape that exercises it: one pile plus many separated fragments, so the
+    inner loop keeps finding reads in other components and the index is reused rather than skipped.
+    """
+    import random
+
+    rng = random.Random(23)
+    molecule = "".join(rng.choice("ACGT") for _ in range(900))
+    # A pile at 0, then fragments far enough apart that several stay separate components.
+    offsets = [0] * 12 + [120, 240, 360, 480, 600, 720, 810]
+    reads = tmp_path / "many.fq"
+    reads.write_text(_tiled(molecule, offsets, 90))
+
+    summary = run(reads, tmp_path / "asm", sample_id="S1", contig=True)
+    assert summary["groups"] == 1
+    # Whatever the partition is, it must be reachable and stable -- rerunning gives the same bytes.
+    first = (tmp_path / "asm" / "S1.mig.tsv").read_text()
+    rerun = run(reads, tmp_path / "asm2", sample_id="S1", contig=True)
+    assert rerun["molecules"] == summary["molecules"]
+    assert (tmp_path / "asm2" / "S1.mig.tsv").read_text() == first
+
+
 def test_contig_mode_never_bridges_a_gap(tmp_path):
     """Two islands of reads sharing a barcode but no sequence are two contigs. A single consensus
     over them would assert 100 nt that no read covers."""

--- a/tests/synthetic/test_dual_end.py
+++ b/tests/synthetic/test_dual_end.py
@@ -159,6 +159,45 @@ def test_the_skew_warning_is_weighed_against_the_barcode_not_the_umi(tmp_path):
     assert "barcode is 26 nt but only" in report
 
 
+def test_a_cell_that_fills_the_key_on_its_own_does_not_shift_by_64(tmp_path):
+    """32 nt of cell and no UMI: the one layout that reaches a 64-bit shift of a 64-bit key.
+
+    `>> 64` is undefined, not zero -- the count is masked to 6 bits on x86, so it becomes `>> 0`
+    and the UMI is ORed back on top of the cell barcode instead of below it. Verified under UBSan
+    that the unguarded expression is flagged and returns a different value from the guarded one.
+    The length check permits this layout (32 + 0 fits the key exactly), so the guard is what makes
+    it defined: with no UMI the molecule key is the cell key, which is what these ten reads say.
+    """
+    with gzip.open(tmp_path / "r1.fq.gz", "wt") as f1, gzip.open(tmp_path / "r2.fq.gz", "wt") as f2:
+        for i in range(10):
+            f1.write(f"@r{i}\n{'ACGT' * 8}\n+\n{'I' * 32}\n")
+            f2.write(f"@r{i}\n{'A' * 90}\n+\n{'I' * 90}\n")
+    (tmp_path / "bc.txt").write_text(f"P\t{'X' * 32}\n")
+
+    s = run(tmp_path / "r1.fq.gz", tmp_path / "bc.txt", tmp_path / "out",
+            reads2=tmp_path / "r2.fq.gz", max_offset=0)["samples"][0]
+    assert (s["cell_length"], s["umi_length"], s["barcode_length"]) == (32, 0, 32)
+    assert s["reads"] == 10
+    assert s["umis"] == 1, "ten reads of one cell barcode are one key, not ten"
+
+
+def test_a_barcode_too_long_for_the_key_is_refused_by_name(tmp_path):
+    """20 nt of cell and 16 of UMI clear their own bounds and their 36 nt sum does not fit at all.
+
+    Before the guard this counted 1 distinct barcode where there were 2: the key holds 32 bases,
+    so two molecules sharing their first 32 and differing past them packed identically and merged.
+    That is the error nothing downstream can detect, which is why it is refused rather than warned
+    about -- and refused when the pattern compiles, where the offending row can still be named.
+    """
+    (tmp_path / "bc.txt").write_text(f"P\t{'X' * 20}{'N' * 16}\n")
+    with gzip.open(tmp_path / "r1.fq.gz", "wt") as f1, gzip.open(tmp_path / "r2.fq.gz", "wt") as f2:
+        f1.write(f"@r0\n{'ACGT' * 9}\n+\n{'I' * 36}\n")
+        f2.write(f"@r0\n{'A' * 90}\n+\n{'I' * 90}\n")
+    with pytest.raises(RuntimeError, match="32 bases in total"):
+        run(tmp_path / "r1.fq.gz", tmp_path / "bc.txt", tmp_path / "out",
+            reads2=tmp_path / "r2.fq.gz", max_offset=0)
+
+
 def test_a_positional_pattern_is_refused_by_a_free_scan(tmp_path):
     """No anchor means nothing to search for. Saying so beats matching everywhere.
 


### PR DESCRIPTION
Two robustness fixes found by auditing the 2.5.0 counter change, and one measured optimization.

## A barcode too long for the key silently merged molecules

`checkout` validated the cell and UMI lengths **apart** and grouped molecules on their **sum**. 20 nt of cell and 16 of UMI each clear their own 32-base bound; their 36 nt total does not fit the 64-bit key at all.

Measured before the guard: **1 distinct barcode where there were 2** — two molecules sharing their first 32 bases and differing past them packed identically. That is the wrong-merge class the repo treats as unrecoverable. Refused now when the pattern compiles, where the offending barcode-table row can still be named.

A dual-end sample is checked across **both mates** in `PatternSet::add`, since the slave extends the UMI on the other mate and no single `compile` call can see the total (16 + 12 + 12 = 40 is three individually legal parts).

## `>> 64` is undefined, not zero

x86 masks the shift count to 6 bits, so `>> 64` becomes `>> 0` and the UMI is ORed back on top of the cell barcode instead of below it. A 32 nt cell with no UMI reaches it, and the length check permits that layout because 32 + 0 fits exactly.

Confirmed under UBSan that the old expression is flagged **and returns a different value** from the guarded one, so this was not benign-by-luck on every target.

## `place_reads` indexes each read once, not once per pair

**40,786 -> 150,152 reads/s (3.7x)**, consensus FASTQ and `mig.tsv` MD5-identical.

2.5.0's union-find short-circuit cut the scan count from O(reads²) to O(reads x components) — but 8% of 10x reads are not co-terminal, so a 500-read group carries ~40 components and read 0 was rebuilding its own seed map once for each. Built once per read now, and lazily, so a pure pile never builds one at all.

## The pool that cannot pay

`kChunkReads` named a persistent worker pool as its upgrade path; that claim had never been measured, and it is wrong. `parallel_for`'s whole per-call cost is ~140 us at 16 threads and **flat in the item count**, so only the call count pays it: 0.069 s at 8 k chunks against 0.009 s at 64 k. That 0.060 s is **14% of the 0.42 s** the chunk change is worth on 4 M reads — ~3% of the run. A pool removes exactly that term and nothing else; the rest is the serial read and the barrier tail. Recorded beside the constant instead of built.

## Verification

- `ctest` / doctest: 117 cases, 224,216 assertions
- **UBSan build clean** on the whole C++ suite
- `pytest tests/unit tests/synthetic`: 330 passed, 1 skipped (3 new tests)
- `ruff`: clean; `sphinx-build -W`: clean from a wiped `_build`
- byte-identity of the optimization verified by building both versions and diffing the outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)