### PR TITLE
An empty table is skipped, not failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ prevents. Releases before 2.0.0 are the Groovy MIGEC and are described by their 
 
 ## 2.5.1 — 2026-08-15
 
+### An empty table is skipped, not failed
+
+Never: **a purely positional pattern has no constant bases, so `checkout.quality_calibration.tsv`
+is written with a header and no rows** — the calibration is measured against the pattern's own
+constant bases and 10x has none. `migec plot` handed that to gnuplot, which answered `x range is
+invalid`, and the run reported a *failure*. A chemistry with nothing to calibrate against is not a
+broken run. Found on the real `sc5p_v2_hs_PBMC_1k` run that drew the new README panels.
+
+Empty and missing are reported apart, because the advice differs: a missing table means run the
+stage that writes it, an empty one means the stage ran and had nothing to put in it.
+
 ### The composition table says which half of the barcode a position is in, and two axes stop lying
 
 `checkout.umi_composition.tsv` gains a **`segment`** column, `cell` or `umi`. The table has spanned

--- a/python/migec/plot.py
+++ b/python/migec/plot.py
@@ -471,6 +471,13 @@ plot "{src}" using 2:4 with boxes lc rgb "#1b9e77"
 ]
 
 
+def _has_rows(path: Path) -> bool:
+    """True if the table has a data row under its header. Blank lines do not count."""
+    with open(path) as fh:
+        next(fh, None)
+        return any(line.strip() for line in fh)
+
+
 def _samples(path: Path) -> list[str]:
     """The distinct values of column 1, in file order. One figure per sample."""
     seen: list[str] = []
@@ -510,12 +517,22 @@ def run(
 
     drawn: list[str] = []
     skipped: list[str] = []
+    empty: list[str] = []
     failed: list[str] = []
     for panel in PANELS:
         matches = sorted(src_dir.glob(panel.source))
-        if not matches:
-            skipped.append(panel.name)
+        # A table with a header and no rows is the same case as no table at all, and it is a real
+        # one rather than a corner: a purely positional pattern (10x) has no constant bases, so
+        # `checkout.quality_calibration.tsv` is written empty and there is nothing to calibrate
+        # against. Feeding that to gnuplot got "x range is invalid" on stderr and a failure row in
+        # the report, which reads as a broken run rather than a chemistry without an anchor.
+        present = [m for m in matches if _has_rows(m)]
+        if not present:
+            # Reported apart, because the advice differs: a missing table means run the stage, an
+            # empty one means the stage ran and had nothing to put in it.
+            (empty if matches else skipped).append(panel.name)
             continue
+        matches = present
         for src in matches:
             stem = panel.name if len(matches) == 1 else f"{panel.name}.{src.name.split('.')[0]}"
             for sample in _samples(src) if panel.per_sample else [""]:
@@ -547,6 +564,7 @@ def run(
         "gnuplot": exe or "",
         "drawn": drawn,
         "skipped": skipped,
+        "empty": empty,
         "failed": failed,
         "scripts": sorted(p.name for p in out.glob("*.gp")),
     }
@@ -571,5 +589,11 @@ def format_report(summary: dict) -> str:
         lines.append("")
         lines.append(
             f"no table for: {', '.join(summary['skipped'])} -- run the stage that writes it"
+        )
+    if summary.get("empty"):
+        lines.append("")
+        lines.append(
+            f"nothing to draw for: {', '.join(summary['empty'])} -- the stage ran and wrote an "
+            f"empty table. A purely positional pattern has no constant bases to calibrate against"
         )
     return "\n".join(lines)

--- a/tests/unit/test_plot.py
+++ b/tests/unit/test_plot.py
@@ -12,11 +12,12 @@ import pytest
 
 from migec.plot import PANELS, format_report, run
 
-COMPOSITION = """sample_id\tposition\tA\tC\tG\tT\tentropy_bits\tinformation_bits\tcollision
-S1\t0\t0.25\t0.25\t0.25\t0.25\t2.000000\t0.000000\t0.250000
-S1\t1\t0.40\t0.20\t0.20\t0.20\t1.921928\t0.078072\t0.280000
-S2\t0\t0.10\t0.30\t0.30\t0.30\t1.895462\t0.104538\t0.280000
-"""
+COMPOSITION = (
+    "sample_id\tposition\tsegment\tA\tC\tG\tT\tentropy_bits\tinformation_bits\tcollision\n"
+    "S1\t0\tcell\t0.25\t0.25\t0.25\t0.25\t2.000000\t0.000000\t0.250000\n"
+    "S1\t1\tumi\t0.40\t0.20\t0.20\t0.20\t1.921928\t0.078072\t0.280000\n"
+    "S2\t0\tumi\t0.10\t0.30\t0.30\t0.30\t1.895462\t0.104538\t0.280000\n"
+)
 
 COVERAGE = """sample_id\tmig_size\treads\tunits
 S1\t1\t100\t100
@@ -147,3 +148,30 @@ def test_gnuplot_renders_the_familiar_panels(tmp_path):
     svg = (tmp_path / "plots" / "cell_rank.svg").read_text()
     assert 'width="760"' in svg
     assert 'fill="none"' in svg              # the canvas rect, unfilled
+
+
+def test_a_table_with_a_header_and_no_rows_is_skipped_not_failed(tmp_path):
+    """A purely positional pattern (10x) has no constant bases, so `checkout` writes an EMPTY
+    calibration table -- header, no rows. Handing that to gnuplot got "x range is invalid" on
+    stderr and a failure row in the report, which reads as a broken run rather than as a chemistry
+    with nothing to calibrate against. Measured on the real `sc5p_v2_hs_PBMC_1k` run.
+
+    The two cases are reported apart because the advice differs: a missing table means run the
+    stage, an empty one means the stage ran and had nothing to put in it.
+    """
+    (tmp_path / "checkout.quality_calibration.tsv").write_text(
+        "phred\tbases\tmismatches\tobserved\tnominal\tcalibrated\n"
+    )
+    (tmp_path / "checkout.umi_composition.tsv").write_text(COMPOSITION)
+
+    summary = run(tmp_path, tmp_path / "out", gnuplot="")
+    assert "quality_calibration" in summary["empty"]
+    assert "quality_calibration" not in summary["skipped"]
+    assert not summary["failed"]
+    # ...and no script is written for it either: there is nothing for it to draw.
+    assert not (tmp_path / "out" / "quality_calibration.gp").exists()
+
+    report = format_report(summary)
+    assert "nothing to draw for: quality_calibration" in report
+    # The missing-table advice must not be attached to it -- the stage did run.
+    assert "quality_calibration" not in report.split("no table for:")[1].split("\n")[0]


### PR DESCRIPTION
Folded into 2.5.1, whose tag is being re-cut (nothing was uploaded to PyPI — the publish was cancelled at the environment gate, so the version is still free).

## The bug

A purely positional pattern has **no constant bases**, so `checkout.quality_calibration.tsv` is written with a header and no rows — the calibration is measured against the pattern's own constant bases, and 10x has none.

`migec plot` handed that to gnuplot, which answered `x range is invalid`, and the run reported a **failure**. A chemistry with nothing to calibrate against is not a broken run.

Found on the real `sc5p_v2_hs_PBMC_1k` run that drew the new README panels — the warning was in the output the whole time.

## The fix

An empty table is treated like a missing one, and the two are reported apart because the advice differs:

```
no table for: cycles, kmers, ... -- run the stage that writes it

nothing to draw for: quality_calibration -- the stage ran and wrote an empty table.
A purely positional pattern has no constant bases to calibrate against
```

Also refreshes the plot test fixture, which still carried a composition table without the `segment` column added earlier in this release — so the `umi_pwm` panel test was reading the wrong columns.

## Verification

- `pytest tests/unit tests/synthetic`: 331 passed, 1 skipped
- `ruff` clean, `sphinx-build -W` clean from a wiped `_build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)